### PR TITLE
Fix an unlikely corner case for negative zero

### DIFF
--- a/src/ch/randelshofer/math/FastDoubleParser.java
+++ b/src/ch/randelshofer/math/FastDoubleParser.java
@@ -857,7 +857,7 @@ public class FastDoubleParser {
         // In the slow path, we need to adjust i so that it is > 1<<63 which is always
         // possible, except if i == 0, so we handle i == 0 separately.
         if (i == 0) {
-            return 0.0;
+            return negative ? -0.0 : 0.0;
         }
 
 

--- a/test/ch/randelshofer/math/FastDoubleParserTest.java
+++ b/test/ch/randelshofer/math/FastDoubleParserTest.java
@@ -32,6 +32,10 @@ class FastDoubleParserTest {
         return List.of(
                 dynamicTest("0", () -> testLegalInput("0", 0.0)),
                 dynamicTest("1", () -> testLegalInput("1", 1.0)),
+                dynamicTest("-0", () -> testLegalInput("-0", -0.0)),
+                dynamicTest("-0.0", () -> testLegalInput("-0.0", -0.0)),
+                dynamicTest("-0.0e-22", () -> testLegalInput("-0.0e-22", -0.0e-22)),
+                dynamicTest("-0.0e24", () -> testLegalInput("-0.0e24", -0.0e24)),
                 dynamicTest("10000000000000000000000000000000000000000000e+308",
                         () -> testLegalInput("10000000000000000000000000000000000000000000e+308",
                                 Double.parseDouble("10000000000000000000000000000000000000000000e+308"))),


### PR DESCRIPTION
I'm unaware of any practical benefit of this. But it fixes an
inconsistency with Double.parseDouble().