### PR TITLE
Added CI to use GitHub actions to build and run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: Java CI build and test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        java: [16]
+      fail-fast: false
+      max-parallel: 4
+    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Compile FastDoubleParser
+        run: javac -d out -encoding utf8 -sourcepath src/main/java test/main/java/org/fastdoubleparser/parser/FastDoubleParserBenchmark.java  
+      - name: Run Test 1
+        run: java -classpath out org.fastdoubleparser.parser.FastDoubleParserBenchmark
+      - name: Run Test 2
+        run: java -classpath out org.fastdoubleparser.parser.FastDoubleParserBenchmark data/canada.txt
+...


### PR DESCRIPTION
Added CI to use GitHub actions to build and run tests. This project can take advantage of GitHub's runners whenever there is a push event. What's nice too is it will build and run tests on MacOS, Windows, and Linux using the latest Java 16 that supports `records`. 