### PR TITLE
Empty CharSequence should throw NumberFormatException, not IllegalArgumentException

### DIFF
--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromCharSequence.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromCharSequence.java
@@ -180,7 +180,7 @@ abstract class AbstractJavaFloatingPointBitsFromCharSequence extends AbstractFlo
         // -------------------
         int index = skipWhitespace(str, offset, endIndex);
         if (index == endIndex) {
-            throw new IllegalArgumentException(SYNTAX_ERROR);
+            throw new NumberFormatException(SYNTAX_ERROR);
         }
         char ch = str.charAt(index);
 

--- a/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaDoubleParserTest.java
+++ b/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaDoubleParserTest.java
@@ -5,6 +5,7 @@
 package ch.randelshofer.fastdoubleparser;
 
 import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 
 import java.nio.charset.StandardCharsets;
@@ -13,6 +14,7 @@ import java.util.function.ToDoubleFunction;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
 /**
@@ -69,6 +71,28 @@ public class JavaDoubleParserTest extends AbstractJavaFloatValueParserTest {
                         () -> test(t, u -> JavaDoubleParser.parseDouble(u.input().toString().toCharArray(), u.charOffset(), u.charLength()))));
     }
 
+    @Test
+    public void emptyCharSequenceThrowsNumberFormatException() {
+        assertThrows(NumberFormatException.class, () -> {
+            // to make explicit we are calling JavaDoubleParser.parseDouble(CharSequence)
+            final CharSequence cs = "";
+            JavaDoubleParser.parseDouble(cs);
+        });
+    }
+
+    @Test
+    public void emptyByteArrayThrowsNumberFormatException() {
+        assertThrows(NumberFormatException.class, () -> {
+            JavaDoubleParser.parseDouble(new byte[0]);
+        });
+    }
+
+    @Test
+    public void emptyCharArrayThrowsNumberFormatException() {
+        assertThrows(NumberFormatException.class, () -> {
+            JavaDoubleParser.parseDouble(new char[0]);
+        });
+    }
 
     private void test(NumberTestData d, ToDoubleFunction<NumberTestData> f) {
         if (d.expectedErrorMessage() != null) {


### PR DESCRIPTION
Currently:
* `JavaDoubleParser.parseDouble(new byte[0])` throws a NumberFormatException
* `JavaDoubleParser.parseDouble(new char[0])` throws a NumberFormatException
* `JavaDoubleParser.parseDouble("")` throws an IllegalArgumentException.

I believe the third case is wrong, and was just a typo. This PR makes the third case consistent with the first two, and adds tests for all three.
