### PR TITLE
Ensure VarHandle exact semantics

### DIFF
--- a/fastdoubleparser-java17/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleSwar.java
+++ b/fastdoubleparser-java17/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleSwar.java
@@ -35,13 +35,13 @@ import java.nio.ByteOrder;
 class FastDoubleSwar {
 
     private final static VarHandle readLongLE =
-            MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
+            MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN).withInvokeExactBehavior();
     private final static VarHandle readIntLE =
-            MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
+            MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN).withInvokeExactBehavior();
     private final static VarHandle readIntBE =
-            MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.BIG_ENDIAN);
+            MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.BIG_ENDIAN).withInvokeExactBehavior();
     private final static VarHandle readLongBE =
-            MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.BIG_ENDIAN);
+            MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.BIG_ENDIAN).withInvokeExactBehavior();
 
     public static boolean isEightDigits(byte[] a, int offset) {
         return isEightDigitsUtf8((long) readLongLE.get(a, offset));

--- a/fastdoubleparser-java19/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleSwar.java
+++ b/fastdoubleparser-java19/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleSwar.java
@@ -35,13 +35,13 @@ import java.nio.ByteOrder;
 class FastDoubleSwar {
 
     private final static VarHandle readLongLE =
-            MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
+            MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN).withInvokeExactBehavior();
     private final static VarHandle readIntLE =
-            MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
+            MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN).withInvokeExactBehavior();
     private final static VarHandle readIntBE =
-            MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.BIG_ENDIAN);
+            MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.BIG_ENDIAN).withInvokeExactBehavior();
     private final static VarHandle readLongBE =
-            MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.BIG_ENDIAN);
+            MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.BIG_ENDIAN).withInvokeExactBehavior();
 
     public static boolean isEightDigits(byte[] a, int offset) {
         return isEightDigitsUtf8((long) readLongLE.get(a, offset));


### PR DESCRIPTION
Ensure we use VarHandle exact semantics so they can be optimized away.

This shouldn't make a performance difference as the types match, it just verifies the types match and throws an exception otherwise.

See [JDK-8254354](https://bugs.openjdk.org/browse/JDK-8254354)