### PR TITLE
Remove not needed TEN_POW_16 constants

### DIFF
--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharArray.java
@@ -81,7 +81,6 @@ final class JavaBigDecimalFromCharArray extends AbstractNumberParser {
      */
     private final static int MAX_DIGIT_COUNT = 1_292_782_621;
     private final static long MAX_EXPONENT_NUMBER = Integer.MAX_VALUE;
-    private final static BigInteger TEN_POW_16 = BigInteger.valueOf(10_000_000_000_000_000L);
 
     /**
      * Creates a new instance.

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharSequence.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharSequence.java
@@ -82,8 +82,6 @@ final class JavaBigDecimalFromCharSequence extends AbstractNumberParser {
     private final static int MAX_DIGIT_COUNT = 1_292_782_621;
     private final static long MAX_EXPONENT_NUMBER = Integer.MAX_VALUE;
 
-    private final static BigInteger TEN_POW_16 = BigInteger.valueOf(10_000_000_000_000_000L);
-
     /**
      * Creates a new instance.
      */


### PR DESCRIPTION
The `TEN_POW_16` constants are only referenced in the `FastIntegerMath` classes, not the  `JavaBigDecimalFrom*` classes.