### PR TITLE
Introduce constants for parsers

### DIFF
--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalParser.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalParser.java
@@ -100,6 +100,11 @@ import java.math.BigInteger;
  */
 public class JavaBigDecimalParser {
 
+    private static final JavaBigDecimalFromByteArray BYTE_ARRAY_PARSER = new JavaBigDecimalFromByteArray();
+
+    private static final JavaBigDecimalFromCharArray CHAR_ARRAY_PARSER = new JavaBigDecimalFromCharArray();
+
+    private static final JavaBigDecimalFromCharSequence CHARSEQUENCE_PARSER = new JavaBigDecimalFromCharSequence();
 
     /**
      * Don't let anyone instantiate this class.
@@ -133,7 +138,7 @@ public class JavaBigDecimalParser {
      * @throws NumberFormatException    if the string can not be parsed successfully
      */
     public static BigDecimal parseBigDecimal(CharSequence str, int offset, int length) throws NumberFormatException {
-        return new JavaBigDecimalFromCharSequence().parseBigDecimalString(str, offset, length, false);
+        return CHARSEQUENCE_PARSER.parseBigDecimalString(str, offset, length, false);
     }
 
     /**
@@ -163,7 +168,7 @@ public class JavaBigDecimalParser {
      * @throws NumberFormatException if the string can not be parsed successfully
      */
     public static BigDecimal parseBigDecimal(byte[] str, int offset, int length) throws NumberFormatException {
-        return new JavaBigDecimalFromByteArray().parseBigDecimalString(str, offset, length, false);
+        return BYTE_ARRAY_PARSER.parseBigDecimalString(str, offset, length, false);
     }
 
     /**
@@ -194,7 +199,7 @@ public class JavaBigDecimalParser {
      * @throws NumberFormatException    if the string can not be parsed successfully
      */
     public static BigDecimal parseBigDecimal(char[] str, int offset, int length) throws NumberFormatException {
-        return new JavaBigDecimalFromCharArray().parseBigDecimalString(str, offset, length, false);
+        return CHAR_ARRAY_PARSER.parseBigDecimalString(str, offset, length, false);
     }
 
     /**
@@ -222,7 +227,7 @@ public class JavaBigDecimalParser {
      * @throws NumberFormatException    if the string can not be parsed successfully
      */
     public static BigDecimal parallelParseBigDecimal(CharSequence str, int offset, int length) throws NumberFormatException {
-        return new JavaBigDecimalFromCharSequence().parseBigDecimalString(str, offset, length, false);
+        return CHARSEQUENCE_PARSER.parseBigDecimalString(str, offset, length, false);
     }
 
     /**
@@ -252,7 +257,7 @@ public class JavaBigDecimalParser {
      * @throws NumberFormatException    if the string can not be parsed successfully
      */
     public static BigDecimal parallelParseBigDecimal(byte[] str, int offset, int length) throws NumberFormatException {
-        return new JavaBigDecimalFromByteArray().parseBigDecimalString(str, offset, length, true);
+        return BYTE_ARRAY_PARSER.parseBigDecimalString(str, offset, length, true);
     }
 
     /**
@@ -283,6 +288,6 @@ public class JavaBigDecimalParser {
      * @throws NumberFormatException    if the string can not be parsed successfully
      */
     public static BigDecimal parallelParseBigDecimal(char[] str, int offset, int length) throws NumberFormatException {
-        return new JavaBigDecimalFromCharArray().parseBigDecimalString(str, offset, length, true);
+        return CHAR_ARRAY_PARSER.parseBigDecimalString(str, offset, length, true);
     }
 }

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigIntegerParser.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigIntegerParser.java
@@ -52,6 +52,13 @@ import java.math.BigInteger;
  * </ul>
  */
 public class JavaBigIntegerParser {
+
+    private static final JavaBigIntegerFromByteArray BYTE_ARRAY_PARSER = new JavaBigIntegerFromByteArray();
+
+    private static final JavaBigIntegerFromCharArray CHAR_ARRAY_PARSER = new JavaBigIntegerFromCharArray();
+
+    private static final JavaBigIntegerFromCharSequence CHARSEQUENCE_PARSER = new JavaBigIntegerFromCharSequence();
+
     /**
      * Don't let anyone instantiate this class.
      */
@@ -82,7 +89,7 @@ public class JavaBigIntegerParser {
      * @throws NumberFormatException    if the string can not be parsed successfully
      */
     public static BigInteger parseBigInteger(CharSequence str, int offset, int length) {
-        return new JavaBigIntegerFromCharSequence().parseBigIntegerLiteral(str, offset, length, false);
+        return CHARSEQUENCE_PARSER.parseBigIntegerLiteral(str, offset, length, false);
     }
 
     /**
@@ -113,7 +120,7 @@ public class JavaBigIntegerParser {
      * @throws NumberFormatException    if the string can not be parsed successfully
      */
     public static BigInteger parseBigInteger(byte[] str, int offset, int length) {
-        return new JavaBigIntegerFromByteArray().parseBigIntegerLiteral(str, offset, length, false);
+        return BYTE_ARRAY_PARSER.parseBigIntegerLiteral(str, offset, length, false);
     }
 
     /**
@@ -144,7 +151,7 @@ public class JavaBigIntegerParser {
      * @throws NumberFormatException    if the string can not be parsed successfully
      */
     public static BigInteger parseBigInteger(char[] str, int offset, int length) {
-        return new JavaBigIntegerFromCharArray().parseBigIntegerLiteral(str, offset, length, false);
+        return CHAR_ARRAY_PARSER.parseBigIntegerLiteral(str, offset, length, false);
     }
 
     /**
@@ -171,7 +178,7 @@ public class JavaBigIntegerParser {
      * @throws NumberFormatException    if the string can not be parsed successfully
      */
     public static BigInteger parallelParseBigInteger(CharSequence str, int offset, int length) {
-        return new JavaBigIntegerFromCharSequence().parseBigIntegerLiteral(str, offset, length, true);
+        return CHARSEQUENCE_PARSER.parseBigIntegerLiteral(str, offset, length, true);
     }
 
     /**
@@ -202,7 +209,7 @@ public class JavaBigIntegerParser {
      * @throws NumberFormatException    if the string can not be parsed successfully
      */
     public static BigInteger parallelParseBigInteger(byte[] str, int offset, int length) {
-        return new JavaBigIntegerFromByteArray().parseBigIntegerLiteral(str, offset, length, true);
+        return BYTE_ARRAY_PARSER.parseBigIntegerLiteral(str, offset, length, true);
     }
 
     /**
@@ -233,6 +240,6 @@ public class JavaBigIntegerParser {
      * @throws NumberFormatException    if the string can not be parsed successfully
      */
     public static BigInteger parallelParseBigInteger(char[] str, int offset, int length) {
-        return new JavaBigIntegerFromCharArray().parseBigIntegerLiteral(str, offset, length, true);
+        return CHAR_ARRAY_PARSER.parseBigIntegerLiteral(str, offset, length, true);
     }
 }

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaDoubleParser.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaDoubleParser.java
@@ -157,6 +157,11 @@ package ch.randelshofer.fastdoubleparser;
  */
 public class JavaDoubleParser {
 
+    private static final JavaDoubleBitsFromByteArray BYTE_ARRAY_PARSER = new JavaDoubleBitsFromByteArray();
+
+    private static final JavaDoubleBitsFromCharArray CHAR_ARRAY_PARSER = new JavaDoubleBitsFromCharArray();
+
+    private static final JavaDoubleBitsFromCharSequence CHARSEQUENCE_PARSER = new JavaDoubleBitsFromCharSequence();
 
     /**
      * Don't let anyone instantiate this class.
@@ -190,7 +195,7 @@ public class JavaDoubleParser {
      * @throws NumberFormatException    if the string can not be parsed successfully
      */
     public static double parseDouble(CharSequence str, int offset, int length) throws NumberFormatException {
-        long bitPattern = new JavaDoubleBitsFromCharSequence().parseFloatingPointLiteral(str, offset, length);
+        long bitPattern = CHARSEQUENCE_PARSER.parseFloatingPointLiteral(str, offset, length);
         return Double.longBitsToDouble(bitPattern);
     }
 
@@ -222,7 +227,7 @@ public class JavaDoubleParser {
      * @throws NumberFormatException if the string can not be parsed successfully
      */
     public static double parseDouble(byte[] str, int offset, int length) throws NumberFormatException {
-        long bitPattern = new JavaDoubleBitsFromByteArray().parseFloatingPointLiteral(str, offset, length);
+        long bitPattern = BYTE_ARRAY_PARSER.parseFloatingPointLiteral(str, offset, length);
         return Double.longBitsToDouble(bitPattern);
     }
 
@@ -254,7 +259,7 @@ public class JavaDoubleParser {
      * @throws NumberFormatException if the string can not be parsed successfully
      */
     public static double parseDouble(char[] str, int offset, int length) throws NumberFormatException {
-        long bitPattern = new JavaDoubleBitsFromCharArray().parseFloatingPointLiteral(str, offset, length);
+        long bitPattern = CHAR_ARRAY_PARSER.parseFloatingPointLiteral(str, offset, length);
         return Double.longBitsToDouble(bitPattern);
     }
 }

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaFloatParser.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaFloatParser.java
@@ -12,6 +12,12 @@ package ch.randelshofer.fastdoubleparser;
  */
 public class JavaFloatParser {
 
+    private static final JavaFloatBitsFromByteArray BYTE_ARRAY_PARSER = new JavaFloatBitsFromByteArray();
+
+    private static final JavaFloatBitsFromCharArray CHAR_ARRAY_PARSER = new JavaFloatBitsFromCharArray();
+
+    private static final JavaFloatBitsFromCharSequence CHARSEQUENCE_PARSER = new JavaFloatBitsFromCharSequence();
+
     /**
      * Don't let anyone instantiate this class.
      */
@@ -44,7 +50,7 @@ public class JavaFloatParser {
      * @throws NumberFormatException    if the string can not be parsed successfully
      */
     public static float parseFloat(CharSequence str, int offset, int length) throws NumberFormatException {
-        long bitPattern = new JavaFloatBitsFromCharSequence().parseFloatingPointLiteral(str, offset, length);
+        long bitPattern = CHARSEQUENCE_PARSER.parseFloatingPointLiteral(str, offset, length);
         return Float.intBitsToFloat((int) bitPattern);
     }
 
@@ -75,7 +81,7 @@ public class JavaFloatParser {
      * @throws NumberFormatException if the string can not be parsed successfully
      */
     public static float parseFloat(byte[] str, int offset, int length) throws NumberFormatException {
-        long bitPattern = new JavaFloatBitsFromByteArray().parseFloatingPointLiteral(str, offset, length);
+        long bitPattern = BYTE_ARRAY_PARSER.parseFloatingPointLiteral(str, offset, length);
         return Float.intBitsToFloat((int) bitPattern);
     }
 
@@ -106,7 +112,7 @@ public class JavaFloatParser {
      * @throws NumberFormatException if the string can not be parsed successfully
      */
     public static float parseFloat(char[] str, int offset, int length) throws NumberFormatException {
-        long bitPattern = new JavaFloatBitsFromCharArray().parseFloatingPointLiteral(str, offset, length);
+        long bitPattern = CHAR_ARRAY_PARSER.parseFloatingPointLiteral(str, offset, length);
         return Float.intBitsToFloat((int) bitPattern);
     }
 }

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JsonDoubleParser.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JsonDoubleParser.java
@@ -36,6 +36,11 @@ package ch.randelshofer.fastdoubleparser;
  */
 public class JsonDoubleParser {
 
+    private static final JsonDoubleBitsFromByteArray BYTE_ARRAY_PARSER = new JsonDoubleBitsFromByteArray();
+
+    private static final JsonDoubleBitsFromCharArray CHAR_ARRAY_PARSER = new JsonDoubleBitsFromCharArray();
+
+    private static final JsonDoubleBitsFromCharSequence CHARSEQUENCE_PARSER = new JsonDoubleBitsFromCharSequence();
 
     /**
      * Don't let anyone instantiate this class.
@@ -69,7 +74,7 @@ public class JsonDoubleParser {
      * @throws NumberFormatException    if the string can not be parsed successfully
      */
     public static double parseDouble(CharSequence str, int offset, int length) throws NumberFormatException {
-        long bitPattern = new JsonDoubleBitsFromCharSequence().parseNumber(str, offset, length);
+        long bitPattern = CHARSEQUENCE_PARSER.parseNumber(str, offset, length);
         return Double.longBitsToDouble(bitPattern);
     }
 
@@ -101,7 +106,7 @@ public class JsonDoubleParser {
      * @throws NumberFormatException if the string can not be parsed successfully
      */
     public static double parseDouble(byte[] str, int offset, int length) throws NumberFormatException {
-        long bitPattern = new JsonDoubleBitsFromByteArray().parseNumber(str, offset, length);
+        long bitPattern = BYTE_ARRAY_PARSER.parseNumber(str, offset, length);
         return Double.longBitsToDouble(bitPattern);
     }
 
@@ -132,7 +137,7 @@ public class JsonDoubleParser {
      * @throws NumberFormatException if the string can not be parsed successfully
      */
     public static double parseDouble(char[] str, int offset, int length) throws NumberFormatException {
-        long bitPattern = new JsonDoubleBitsFromCharArray().parseNumber(str, offset, length);
+        long bitPattern = CHAR_ARRAY_PARSER.parseNumber(str, offset, length);
         return Double.longBitsToDouble(bitPattern);
     }
 }


### PR DESCRIPTION
The `*FromByteArray`, `*FromCharArray` and `*FromCharSequence` classes are stateless and their references in the `*Parser` classes can be made constants.

I was working on a patch for Jackson to make `double` parsing work on `char[]` directly without allocating a `String`. When profiling the allocation rate did not go down as much as expected. The reason was that I got a lot of `JavaDoubleBitsFromCharArray` allocations in `JavaDoubleParser`. In theory escape analysis should catch these and scalar replacement should eliminate them. It does not. I haven't looked into it, maybe the method is already too large.

![allocations-before](https://user-images.githubusercontent.com/471021/208924183-870169a5-f838-446a-b78d-740bee461925.png)

![gcs-before](https://user-images.githubusercontent.com/471021/208924175-9e80de35-1da0-4ff8-8ccc-18aba486a89e.png)

After the changes the allocations and GCs are gone.

![allocations-after](https://user-images.githubusercontent.com/471021/208924187-37c2bb8e-4563-4efc-8d11-063f6a113f85.png)

![gcs-after](https://user-images.githubusercontent.com/471021/208924180-23467284-a22d-4b1c-895d-363fe09b477b.png)

I'm seeing a small performance improvement but it's hard to be sure as the deviation is still quite large.
