### PR TITLE
More efficient character group check

### DIFF
--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromByteArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromByteArray.java
@@ -133,7 +133,7 @@ abstract class AbstractJavaFloatingPointBitsFromByteArray extends AbstractFloatV
         // Skip optional FloatTypeSuffix
         // long-circuit-or is faster than short-circuit-or
         // ------------------------
-        if (ch == 'd' | ch == 'D' | ch == 'f' | ch == 'F') {
+        if ((ch | 0x22) == 'f') { // ~ "fFdD"
             index++;
         }
 
@@ -228,7 +228,7 @@ abstract class AbstractJavaFloatingPointBitsFromByteArray extends AbstractFloatV
         final boolean hasLeadingZero = ch == '0';
         if (hasLeadingZero) {
             ch = charAt(str, ++index, endIndex);
-            if (ch == 'x' || ch == 'X') {
+            if ((ch | 0x20) == 'x') {// equals ignore case
                 return parseHexFloatingPointLiteral(str, index + 1, offset, endIndex, isNegative);
             }
         }
@@ -331,7 +331,7 @@ abstract class AbstractJavaFloatingPointBitsFromByteArray extends AbstractFloatV
         // Skip optional FloatTypeSuffix
         // long-circuit-or is faster than short-circuit-or
         // ------------------------
-        if (ch == 'd' | ch == 'D' | ch == 'f' | ch == 'F') {
+        if ((ch | 0x22) == 'f') { // ~ "fFdD"
             index++;
         }
 

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromCharArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromCharArray.java
@@ -137,7 +137,7 @@ abstract class AbstractJavaFloatingPointBitsFromCharArray extends AbstractFloatV
         // Skip optional FloatTypeSuffix
         // long-circuit-or is faster than short-circuit-or
         // ------------------------
-        if (ch == 'd' | ch == 'D' | ch == 'f' | ch == 'F') {
+        if ((ch | 0x22) == 'f') { // ~ "fFdD"
             index++;
         }
 
@@ -231,7 +231,7 @@ abstract class AbstractJavaFloatingPointBitsFromCharArray extends AbstractFloatV
         final boolean hasLeadingZero = ch == '0';
         if (hasLeadingZero) {
             ch = charAt(str, ++index, endIndex);
-            if (ch == 'x' || ch == 'X') {
+            if ((ch | 0x20) == 'x') {// equals ignore case
                 return parseHexFloatLiteral(str, index + 1, offset, endIndex, isNegative);
             }
         }
@@ -334,7 +334,7 @@ abstract class AbstractJavaFloatingPointBitsFromCharArray extends AbstractFloatV
         // Skip optional FloatTypeSuffix
         // long-circuit-or is faster than short-circuit-or
         // ------------------------
-        if (ch == 'd' | ch == 'D' | ch == 'f' | ch == 'F') {
+        if ((ch | 0x22) == 'f') { // ~ "fFdD"
             index++;
         }
 

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromCharSequence.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromCharSequence.java
@@ -134,7 +134,7 @@ abstract class AbstractJavaFloatingPointBitsFromCharSequence extends AbstractFlo
         // Skip optional FloatTypeSuffix
         // long-circuit-or is faster than short-circuit-or
         // ------------------------
-        if (ch == 'd' | ch == 'D' | ch == 'f' | ch == 'F') {
+        if ((ch | 0x22) == 'f') { // ~ "fFdD"
             index++;
         }
 
@@ -228,7 +228,7 @@ abstract class AbstractJavaFloatingPointBitsFromCharSequence extends AbstractFlo
         final boolean hasLeadingZero = ch == '0';
         if (hasLeadingZero) {
             ch = charAt(str, ++index, endIndex);
-            if (ch == 'x' || ch == 'X') {
+            if ((ch | 0x20) == 'x') {
                 return parseHexFloatLiteral(str, index + 1, offset, endIndex, isNegative);
             }
         }
@@ -329,7 +329,7 @@ abstract class AbstractJavaFloatingPointBitsFromCharSequence extends AbstractFlo
         // Skip optional FloatTypeSuffix
         // long-circuit-or is faster than short-circuit-or
         // ------------------------
-        if (ch == 'd' | ch == 'D' | ch == 'f' | ch == 'F') {
+        if ((ch | 0x22) == 'f') { // ~ "fFdD"
             index++;
         }
 

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromCharSequence.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromCharSequence.java
@@ -228,7 +228,7 @@ abstract class AbstractJavaFloatingPointBitsFromCharSequence extends AbstractFlo
         final boolean hasLeadingZero = ch == '0';
         if (hasLeadingZero) {
             ch = charAt(str, ++index, endIndex);
-            if ((ch | 0x20) == 'x') {
+            if ((ch | 0x20) == 'x') {// equals ignore case
                 return parseHexFloatLiteral(str, index + 1, offset, endIndex, isNegative);
             }
         }


### PR DESCRIPTION
The same trick as in [a3c6df6](https://github.com/wrandelshofer/FastDoubleParser/commit/a3c6df6b3660c46f3c2edc2d19c020f254002702).