### PR TITLE
More performant Math.scalb() via direct use of power of two

### DIFF
--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleMath.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleMath.java
@@ -966,23 +966,21 @@ class FastDoubleMath {
      */
     static double tryHexFloatToDoubleTruncated(boolean isNegative, long significand, long exponent, boolean isSignificandTruncated,
                                                long exponentOfTruncatedSignificand) {
-        int power = isSignificandTruncated ? (int) exponentOfTruncatedSignificand : (int) exponent;
+        long power = isSignificandTruncated ? exponentOfTruncatedSignificand : exponent;
         if (DOUBLE_MIN_EXPONENT_POWER_OF_TWO <= power && power <= DOUBLE_MAX_EXPONENT_POWER_OF_TWO) {
-            // Convert the significand into a double.
-            // The cast will round the significand if necessary.
-            // We use Math.abs here, because we treat the significand as an unsigned long.
-            double d = Math.abs((double) significand);
-
             // Scale the significand by the power.
             // This only works if power is within the supported range, so that
             // we do not underflow or overflow.
-            d = d * Math.scalb(1d, power);
-            if (isNegative) {
-                d = -d;
-            }
-            return d;
+            return significand * powerOfTwo(isNegative, power);
         } else {
             return Double.NaN;
         }
+    }
+
+    static double powerOfTwo(boolean isNegative, long exponent) {
+        long doubleSign = isNegative ? 1L << 63 : 0;
+        long doubleExponent = (exponent + DOUBLE_EXPONENT_BIAS) << (DOUBLE_SIGNIFICAND_WIDTH - 1);
+        long doubleValue = doubleSign | doubleExponent;
+        return Double.longBitsToDouble(doubleValue);
     }
 }

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleMath.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleMath.java
@@ -971,10 +971,14 @@ class FastDoubleMath {
             // Scale the significand by the power.
             // This only works if power is within the supported range, so that
             // we do not underflow or overflow.
-            return significand * powerOfTwo(isNegative, power);
+            return scalb(isNegative, significand, power);
         } else {
             return Double.NaN;
         }
+    }
+
+    static double scalb(boolean isNegative, double number, long exponent) {
+        return number * powerOfTwo(isNegative, exponent);
     }
 
     static double powerOfTwo(boolean isNegative, long exponent) {

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleMath.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleMath.java
@@ -977,6 +977,10 @@ class FastDoubleMath {
         }
     }
 
+    static double scalb(double number, long exponent) {
+        return number * Double.longBitsToDouble((exponent + DOUBLE_EXPONENT_BIAS) << (DOUBLE_SIGNIFICAND_WIDTH - 1));
+    }
+
     static double scalb(boolean isNegative, double number, long exponent) {
         return number * powerOfTwo(isNegative, exponent);
     }

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastFloatMath.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastFloatMath.java
@@ -90,10 +90,13 @@ class FastFloatMath {
             // Scale the significand by the power.
             // This only works if power is within the supported range, so that
             // we do not underflow or overflow.
-            return significand * powerOfTwo(isNegative, power);
+            return scalb(significand, isNegative, power);
         } else {
             return Float.NaN;
         }
+    }
+    static float scalb(long number, boolean isNegative, int exponent) {
+        return number * powerOfTwo(isNegative, exponent);
     }
 
     static float powerOfTwo(boolean isNegative, int exponent) {

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastFloatMath.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastFloatMath.java
@@ -86,19 +86,21 @@ class FastFloatMath {
             // Convert the significand into a float.
             // The cast will round the significand if necessary.
             // We use Math.abs here, because we treat the significand as an unsigned long.
-            float d = Math.abs((float) significand);
 
             // Scale the significand by the power.
             // This only works if power is within the supported range, so that
             // we do not underflow or overflow.
-            d = d * Math.scalb(1f, power);
-            if (isNegative) {
-                d = -d;
-            }
-            return d;
+            return significand * powerOfTwo(isNegative, power);
         } else {
             return Float.NaN;
         }
+    }
+
+    static float powerOfTwo(boolean isNegative, int exponent) {
+        int floatSign = isNegative ? 1 << 31 : 0;
+        int floatExponent = (exponent + FLOAT_EXPONENT_BIAS) << (FLOAT_SIGNIFICAND_WIDTH - 1);
+        int floatValue = floatSign | floatExponent;
+        return Float.intBitsToFloat(floatValue);
     }
 
     /**

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FftMultiplier.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FftMultiplier.java
@@ -980,8 +980,8 @@ class FftMultiplier {
             int ii = imagIdx(idxa);
             double real = a[ri];
             double imag = a[ii];
-            a[ri] = Math.scalb(real, n);
-            a[ii] = Math.scalb(imag, n);
+            a[ri] = FastDoubleMath.scalb(real, n);
+            a[ii] = FastDoubleMath.scalb(imag, n);
         }
     }
 

--- a/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/FastDoubleMathTest.java
+++ b/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/FastDoubleMathTest.java
@@ -133,4 +133,11 @@ public class FastDoubleMathTest {
             value = value.multiply(five);
         }
     }
+
+    @Test
+    void powerOfTwo() {
+        for (int i = Double.MIN_EXPONENT; i < Double.MAX_EXPONENT; i++) {
+            assertEquals(Math.scalb(1d, i), FastDoubleMath.powerOfTwo(false, i));
+        }
+    }
 }

--- a/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/FastDoubleMathTest.java
+++ b/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/FastDoubleMathTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.TestFactory;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 
 import static ch.randelshofer.fastdoubleparser.FastDoubleMath.MANTISSA_128;
 import static ch.randelshofer.fastdoubleparser.FastDoubleMath.MANTISSA_64;
@@ -138,6 +139,17 @@ public class FastDoubleMathTest {
     void powerOfTwo() {
         for (int i = Double.MIN_EXPONENT; i < Double.MAX_EXPONENT; i++) {
             assertEquals(Math.scalb(1d, i), FastDoubleMath.powerOfTwo(false, i));
+        }
+    }
+
+    @Test
+    void scalb() {
+        Random r = new Random(0);
+        for (int j = 0; j < 1000; j++) {
+            double d = r.nextDouble();
+            for (int i = Double.MIN_EXPONENT; i < Double.MAX_EXPONENT; i++) {
+                assertEquals(Math.scalb(d, i), FastDoubleMath.scalb(d, i));
+            }
         }
     }
 }

--- a/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/FastFloatMathTest.java
+++ b/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/FastFloatMathTest.java
@@ -1,0 +1,19 @@
+/*
+ * @(#)FastFloatMathTest.java
+ * Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+ */
+package ch.randelshofer.fastdoubleparser;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FastFloatMathTest {
+
+    @Test
+    void powerOfTwo() {
+        for (int i = Float.MIN_EXPONENT; i < Float.MAX_EXPONENT; i++) {
+            assertEquals(Math.scalb(1f, i), FastFloatMath.powerOfTwo(false, i));
+        }
+    }
+}

--- a/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/JmhFastDoubleMath.java
+++ b/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/JmhFastDoubleMath.java
@@ -1,0 +1,27 @@
+/*
+ * @(#)JmhFastDoubleMath.java
+ * Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+ */
+package ch.randelshofer.fastdoubleparser;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(value = 1)
+@Measurement(iterations = 10, time = 1)
+@Warmup(iterations = 2, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@State(Scope.Benchmark)
+public class JmhFastDoubleMath {
+    private boolean negative = true;
+    private long significand = 344_123_233_324_850L;
+    private int exponent = 13;
+
+    @Benchmark
+    public void tryHexFloatToDoubleTruncated(Blackhole blackhole) {
+        blackhole.consume(FastDoubleMath.tryHexFloatToDoubleTruncated(negative, significand, exponent, false, 0));
+    }
+}

--- a/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/JmhFastFloatMath.java
+++ b/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/JmhFastFloatMath.java
@@ -1,0 +1,27 @@
+/*
+ * @(#)JmhFastFloatMath.java
+ * Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+ */
+package ch.randelshofer.fastdoubleparser;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(value = 1)
+@Measurement(iterations = 10, time = 1)
+@Warmup(iterations = 2, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@State(Scope.Benchmark)
+public class JmhFastFloatMath {
+    private boolean negative = true;
+    private long significand = 324850;
+    private int exponent = 13;
+
+    @Benchmark
+    public void hexFloatLiteralToFloat(Blackhole blackhole) {
+        blackhole.consume(FastFloatMath.hexFloatLiteralToFloat(negative, significand, exponent, false, 0));
+    }
+}


### PR DESCRIPTION
`Math.scalb()` also uses internally multiplication by power of two in double type. Even I have not found any cases, where replacement for original method does not work, it should be verified if accuracy was not affected.