### PR TITLE
Invalid hex chars

### DIFF
--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleSwar.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleSwar.java
@@ -427,6 +427,11 @@ class FastDoubleSwar {
         // we don't need to 'and' with 0x80…L here, because we 'and' this with ge_30 anyway.
         //le_37 &= 0x80_80_80_80_80_80_80_80L;
 
+        // Create a predicate for all bytes which are smaller than '0' or greater than 0x7F
+        long lt_00_gt_ff = (chunk | (chunk - 0x3030_3030_3030_3030L)) & 0x8080_8080_8080_8080L;
+        if (lt_00_gt_ff != 0) {
+            return -1;
+        }
 
         // If a character is greater than '9' then it must be greater equal 'a'
         // and smaller  'f'.

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleSwar.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleSwar.java
@@ -411,7 +411,7 @@ class FastDoubleSwar {
         // (This does not have an impact on decimal digits, which is very handy!).
         // Subtract character '0' (0x30) from each of the eight characters
         long vec = (chunk | 0x20_20_20_20_20_20_20_20L) - 0x30_30_30_30_30_30_30_30L;
-        long lt0 = (chunk - 0x30_30_30_30_30_30_30_30L) & 0x80_80_80_80_80_80_80_80L;
+        long lt0 = ((chunk - 0x30_30_30_30_30_30_30_30L) | chunk) & 0x80_80_80_80_80_80_80_80L;
 
         // Create a predicate for all bytes which are greater than '9'-'0' (0x09).
         // The predicate is true if the hsb of a byte is set: (predicate & 0x80) != 0.
@@ -427,12 +427,6 @@ class FastDoubleSwar {
         long le_37 = 0x37_37_37_37_37_37_37_37L + (vec ^ 0x7f_7f_7f_7f_7f_7f_7f_7fL);
         // we don't need to 'and' with 0x80…L here, because we 'and' this with ge_30 anyway.
         //le_37 &= 0x80_80_80_80_80_80_80_80L;
-
-        // Create a predicate for all bytes which are smaller than '0' or greater than 0x7F
-        long lt_00_gt_ff = (chunk | (chunk - 0x3030_3030_3030_3030L)) & 0x8080_8080_8080_8080L;
-        if (lt_00_gt_ff != 0) {
-            return -1;
-        }
 
         // If a character is greater than '9' then it must be greater equal 'a'
         // and smaller  'f'.

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleSwar.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleSwar.java
@@ -411,6 +411,7 @@ class FastDoubleSwar {
         // (This does not have an impact on decimal digits, which is very handy!).
         // Subtract character '0' (0x30) from each of the eight characters
         long vec = (chunk | 0x20_20_20_20_20_20_20_20L) - 0x30_30_30_30_30_30_30_30L;
+        long lt0 = (chunk - 0x30_30_30_30_30_30_30_30L) & 0x80_80_80_80_80_80_80_80L;
 
         // Create a predicate for all bytes which are greater than '9'-'0' (0x09).
         // The predicate is true if the hsb of a byte is set: (predicate & 0x80) != 0.
@@ -435,7 +436,7 @@ class FastDoubleSwar {
 
         // If a character is greater than '9' then it must be greater equal 'a'
         // and smaller  'f'.
-        if (gt_09 != (ge_30 & le_37)) {
+        if ((lt0 | gt_09) != (ge_30 & le_37)) {
             return -1;
         }
 

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleVector.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleVector.java
@@ -62,6 +62,18 @@ class FastDoubleVector {
         return FastDoubleVector.tryToParseEightDigitsUtf16(first, second);
     }
 
+    public static long tryToParseEightHexDigits(CharSequence str, int offset) {
+        long first = (long) str.charAt(offset) << 48
+                | (long) str.charAt(offset + 1) << 32
+                | (long) str.charAt(offset + 2) << 16
+                | (long) str.charAt(offset + 3);
+        long second = (long) str.charAt(offset + 4) << 48
+                | (long) str.charAt(offset + 5) << 32
+                | (long) str.charAt(offset + 6) << 16
+                | (long) str.charAt(offset + 7);
+        return FastDoubleVector.tryToParseEightHexDigitsUtf16(first, second);
+    }
+
     /**
      * Tries to parse eight decimal digits from a char array using the
      * Java Vector API.

--- a/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/AbstractEightDigitsTest.java
+++ b/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/AbstractEightDigitsTest.java
@@ -7,6 +7,7 @@ package ch.randelshofer.fastdoubleparser;
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.TestFactory;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -61,7 +62,23 @@ public abstract class AbstractEightDigitsTest {
         );
     }
 
+    @TestFactory
+    public List<DynamicNode> dynamicTestsAllIllegalEightHexDigitsLiterals() {
+        List<DynamicNode> tests = new ArrayList<>();
+        for (int i = 0; i < 256; i++) {
+            final char c = (char) i;
+            if ((c < '0' || c > '9') && (c < 'A' || c > 'F') && (c < 'a' || c > 'f')) {
+                byte[] a = new byte[8];
+                Arrays.fill(a, (byte) c);
+                tests.add(dynamicTest(i + " " + c, () -> testHex(a, 0, -1)));
+            }
+        }
+        return tests;
+    }
+
     abstract void testDec(String s, int offset, int expected);
 
     abstract void testHex(String s, int offset, long expected);
+
+    abstract void testHex(byte[] b, int offset, long expected);
 }

--- a/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/EarlyAccessEightDigitsVectorTest.java
+++ b/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/EarlyAccessEightDigitsVectorTest.java
@@ -12,9 +12,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class EarlyAccessEightDigitsVectorTest extends AbstractEightDigitsTest {
     @Override
     void testDec(String s, int offset, int expected) {
+        int actual = FastDoubleVector.tryToParseEightDigits(s, offset);
+        assertEquals(expected, actual);
+
         char[] chars = s.toCharArray();
 
-        int actual = FastDoubleVector.tryToParseEightDigitsUtf16(chars, offset);
+        actual = FastDoubleVector.tryToParseEightDigitsUtf16(chars, offset);
         assertEquals(expected, actual);
 
 
@@ -59,23 +62,30 @@ public class EarlyAccessEightDigitsVectorTest extends AbstractEightDigitsTest {
 
     @Override
     void testHex(String s, int offset, long expected) {
-        char[] chars = s.toCharArray();
-        long actual = FastDoubleVector.tryToParseEightHexDigitsUtf16(chars, offset);
+        long actual = FastDoubleVector.tryToParseEightHexDigits(s, offset);
         if (expected < 0) {
             assertTrue(actual < 0);
         } else {
             assertEquals(expected, actual);
         }
 
-        long first = (long) chars[offset + 0]
-                | (long) chars[offset + 1] << 16
-                | (long) chars[offset + 2] << 32
-                | (long) chars[offset + 3] << 48;
+        char[] chars = s.toCharArray();
+        actual = FastDoubleVector.tryToParseEightHexDigitsUtf16(chars, offset);
+        if (expected < 0) {
+            assertTrue(actual < 0);
+        } else {
+            assertEquals(expected, actual);
+        }
 
-        long second = (long) chars[offset + 4]
-                | (long) chars[offset + 5] << 16
-                | (long) chars[offset + 6] << 32
-                | (long) chars[offset + 7] << 48;
+        long first = (long) chars[offset + 0] << 48
+                | (long) chars[offset + 1] << 32
+                | (long) chars[offset + 2] << 16
+                | (long) chars[offset + 3];
+
+        long second = (long) chars[offset + 4] << 48
+                | (long) chars[offset + 5] << 32
+                | (long) chars[offset + 6] << 16
+                | (long) chars[offset + 7];
         actual = FastDoubleVector.tryToParseEightHexDigitsUtf16(first, second);
         if (expected < 0) {
             assertTrue(actual < 0);
@@ -83,12 +93,16 @@ public class EarlyAccessEightDigitsVectorTest extends AbstractEightDigitsTest {
             assertEquals(expected, actual);
         }
 
-        actual = FastDoubleVector.tryToParseEightHexDigitsUtf8(s.getBytes(StandardCharsets.UTF_8), offset);
+        testHex(s.getBytes(StandardCharsets.UTF_8), offset, expected);
+    }
+
+    @Override
+    void testHex(byte[] b, int offset, long expected) {
+        long actual = FastDoubleVector.tryToParseEightHexDigitsUtf8(b, offset);
         if (expected < 0) {
             assertTrue(actual < 0);
         } else {
             assertEquals(expected, actual);
         }
-
     }
 }

--- a/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/EightDigitsSwarTest.java
+++ b/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/EightDigitsSwarTest.java
@@ -92,12 +92,16 @@ public class EightDigitsSwarTest extends AbstractEightDigitsTest {
             assertEquals(expected, actual);
         }
 
-        actual = FastDoubleSwar.tryToParseEightHexDigits(s.getBytes(StandardCharsets.UTF_8), offset);
+        testHex(s.getBytes(StandardCharsets.UTF_8), offset, expected);
+    }
+
+    @Override
+    void testHex(byte[] b, int offset, long expected) {
+        long actual = FastDoubleSwar.tryToParseEightHexDigits(b, offset);
         if (expected < 0) {
             assertTrue(actual < 0);
         } else {
             assertEquals(expected, actual);
         }
-
     }
 }


### PR DESCRIPTION
Added missing check for digit characters being equal to `'0'` or greater. As the used way of tightly coupled SWAR testing of character being is around byte range, some character from upper half of ASCII were considered as valid also not filter by existing checks and thus check for characters being less or equal to `'9'` added also.

There may be better way - smaller number of operations - for testing hexadecimal characters after this change.

There were some troubles with little / big endian integer encoding, it should be verified whether they do not occur on other platform than tested - Intel.