### PR TITLE
Unified check bounds for input size

### DIFF
--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractBigDecimalParser.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractBigDecimalParser.java
@@ -1,0 +1,57 @@
+/*
+ * @(#)AbstractBigDecimalParser.java
+ * Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+ */
+package ch.randelshofer.fastdoubleparser;
+
+public abstract class AbstractBigDecimalParser extends ch.randelshofer.fastdoubleparser.AbstractNumberParser {
+    protected final static int MAX_INPUT_LENGTH = 1_292_782_635;
+
+    /**
+     * Threshold on the number of input characters for selecting the
+     * algorithm optimised for few digits in the significand vs. the algorithm for many
+     * digits in the significand.
+     * <p>
+     * Set this to {@link Integer#MAX_VALUE} if you only want to use
+     * the algorithm optimised for few digits in the significand.
+     * <p>
+     * Set this to {@code 0} if you only want to use the algorithm for
+     * long inputs.
+     * <p>
+     * Rationale for choosing a specific threshold value:
+     * We speculate that we only need to use the algorithm for large inputs
+     * if there is zero chance, that we can parse the input with the algorithm
+     * for small inputs.
+     * <pre>
+     * optional significant sign = 1
+     * 18 significant digits = 18
+     * optional decimal point in significant = 1
+     * optional exponent = 1
+     * optional exponent sign = 1
+     * 10 exponent digits = 10
+     * </pre>
+     */
+    public static final int MANY_DIGITS_THRESHOLD = 1 + 18 + 1 + 1 + 1 + 10;
+    protected final static long MAX_EXPONENT_NUMBER = Integer.MAX_VALUE;
+    /**
+     * See {@link JavaBigDecimalParser}.
+     */
+    protected final static int MAX_DIGIT_COUNT = 1_292_782_621;
+
+    protected static boolean hasManyDigits(int length) {
+        return length >= MANY_DIGITS_THRESHOLD;
+    }
+
+    protected static int checkBigDecimalBounds(int size, int offset, int length) {
+        return checkBounds(size, offset, length, MAX_INPUT_LENGTH);
+    }
+
+    protected static void checkParsedBigDecimalBounds(boolean illegal, int index, int endIndex, int digitCount, long exponent) {
+        if (illegal || index < endIndex || digitCount == 0) {
+            throw new NumberFormatException(SYNTAX_ERROR);
+        }
+        if (exponent <= Integer.MIN_VALUE || exponent > Integer.MAX_VALUE || digitCount > MAX_DIGIT_COUNT) {
+            throw new NumberFormatException(VALUE_EXCEEDS_LIMITS);
+        }
+    }
+}

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractBigIntegerParser.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractBigIntegerParser.java
@@ -1,0 +1,40 @@
+/*
+ * @(#)AbstractBigIntegerParser.java
+ * Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+ */
+package ch.randelshofer.fastdoubleparser;
+public abstract class AbstractBigIntegerParser extends AbstractNumberParser {
+    private final static int MAX_INPUT_LENGTH = 1_292_782_622;
+
+    /**
+     * The resulting value must fit into {@code 2^31 - 1} bits.
+     * The decimal representation of {@code 2^31 - 1} bits has 646,456,993 digits.
+     */
+    private static final int MAX_DECIMAL_DIGITS = 646_456_993;
+
+    /**
+     * The resulting value must fit into {@code 2^31 - 1} bits.
+     * The hexadecimal representation of {@code 2^31 - 1} bits has 536,870,912 digits.
+     */
+    private static final int MAX_HEX_DIGITS = 536_870_912;
+
+    protected static boolean hasManyDigits(int length) {
+        return length > 18;
+    }
+
+    protected static int checkBigIntegerBounds(int size, int offset, int length) {
+        return AbstractNumberParser.checkBounds(size, offset, length, MAX_INPUT_LENGTH);
+    }
+
+    protected static void checkHexBigIntegerBounds(int numDigits) {
+        if (numDigits > MAX_HEX_DIGITS) {
+            throw new NumberFormatException(AbstractNumberParser.VALUE_EXCEEDS_LIMITS);
+        }
+    }
+
+    protected static void checkDecBigIntegerBounds(int numDigits) {
+        if (numDigits > MAX_DECIMAL_DIGITS) {
+            throw new NumberFormatException(AbstractNumberParser.VALUE_EXCEEDS_LIMITS);
+        }
+    }
+}

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractFloatValueParser.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractFloatValueParser.java
@@ -31,4 +31,7 @@ abstract class AbstractFloatValueParser extends AbstractNumberParser {
      */
     final static int MAX_EXPONENT_NUMBER = 1024;
 
+    protected static int checkFloatBounds(int size, int offset, int length) {
+        return checkBounds(size, offset, length, MAX_INPUT_LENGTH);
+    }
 }

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromByteArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromByteArray.java
@@ -194,10 +194,7 @@ abstract class AbstractJavaFloatingPointBitsFromByteArray extends AbstractFloatV
      * otherwise, {@code -1L}.
      */
     public long parseFloatingPointLiteral(byte[] str, int offset, int length) {
-        final int endIndex = offset + length;
-        if (offset < 0 || endIndex < offset || endIndex > str.length || length > MAX_INPUT_LENGTH) {
-            throw new IllegalArgumentException(ILLEGAL_OFFSET_OR_ILLEGAL_LENGTH);
-        }
+        final int endIndex = checkFloatBounds(str.length, offset, length);
 
         // Skip leading whitespace
         // -------------------

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromCharArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromCharArray.java
@@ -197,10 +197,7 @@ abstract class AbstractJavaFloatingPointBitsFromCharArray extends AbstractFloatV
      * otherwise, {@code -1L}.
      */
     public long parseFloatingPointLiteral(char[] str, int offset, int length) {
-        final int endIndex = offset + length;
-        if (offset < 0 || endIndex < offset || endIndex > str.length || length > MAX_INPUT_LENGTH) {
-            throw new IllegalArgumentException(ILLEGAL_OFFSET_OR_ILLEGAL_LENGTH);
-        }
+        final int endIndex = checkFloatBounds(str.length, offset, length);
 
         // Skip leading whitespace
         // -------------------

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromCharSequence.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromCharSequence.java
@@ -194,10 +194,7 @@ abstract class AbstractJavaFloatingPointBitsFromCharSequence extends AbstractFlo
      * otherwise, {@code -1L}.
      */
     public final long parseFloatingPointLiteral(CharSequence str, int offset, int length) {
-        final int endIndex = offset + length;
-        if (offset < 0 || endIndex < offset || endIndex > str.length() || length > MAX_INPUT_LENGTH) {
-            throw new IllegalArgumentException(ILLEGAL_OFFSET_OR_ILLEGAL_LENGTH);
-        }
+        final int endIndex = checkFloatBounds(str.length(), offset, length);
 
         // Skip leading whitespace
         // -------------------

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJsonFloatingPointBitsFromByteArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJsonFloatingPointBitsFromByteArray.java
@@ -28,10 +28,7 @@ abstract class AbstractJsonFloatingPointBitsFromByteArray extends AbstractFloatV
      * otherwise, {@code -1L}.
      */
     public final long parseNumber(byte[] str, int offset, int length) {
-        final int endIndex = offset + length;
-        if (offset < 0 || endIndex < offset || endIndex > str.length || length > MAX_INPUT_LENGTH) {
-            throw new IllegalArgumentException(ILLEGAL_OFFSET_OR_ILLEGAL_LENGTH);
-        }
+        final int endIndex = checkFloatBounds(str.length, offset, length);
         int index = offset;
         byte ch = charAt(str, index, endIndex);
 

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJsonFloatingPointBitsFromCharArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJsonFloatingPointBitsFromCharArray.java
@@ -28,10 +28,7 @@ abstract class AbstractJsonFloatingPointBitsFromCharArray extends AbstractFloatV
      * otherwise, {@code -1L}.
      */
     public final long parseNumber(char[] str, int offset, int length) {
-        final int endIndex = offset + length;
-        if (offset < 0 || endIndex < offset || endIndex > str.length || length > MAX_INPUT_LENGTH) {
-            throw new IllegalArgumentException(ILLEGAL_OFFSET_OR_ILLEGAL_LENGTH);
-        }
+        final int endIndex = AbstractFloatValueParser.checkFloatBounds(str.length, offset, length);
         int index = offset;
         char ch = charAt(str, index, endIndex);
 

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJsonFloatingPointBitsFromCharSequence.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJsonFloatingPointBitsFromCharSequence.java
@@ -28,10 +28,7 @@ abstract class AbstractJsonFloatingPointBitsFromCharSequence extends AbstractFlo
      * otherwise, {@code -1L}.
      */
     public final long parseNumber(CharSequence str, int offset, int length) {
-        final int endIndex = offset + length;
-        if (offset < 0 || endIndex < offset || endIndex > str.length() || length > MAX_INPUT_LENGTH) {
-            throw new IllegalArgumentException(ILLEGAL_OFFSET_OR_ILLEGAL_LENGTH);
-        }
+        final int endIndex = checkFloatBounds(str.length(), offset, length);
         int index = offset;
         char ch = charAt(str, index, endIndex);
 

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractNumberParser.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractNumberParser.java
@@ -122,4 +122,12 @@ abstract class AbstractNumberParser {
         return ch < 128 ? CHAR_TO_HEX_MAP[ch] : -1;
     }
 
+    protected static int checkBounds(int size, int offset, int length, int maxInputLength) {
+        if ((offset | length) < 0 // tricky way to test more negative values at once
+                || offset > size - length // compared difference to avoid overflow when addition used
+                || length > maxInputLength) {
+            throw new IllegalArgumentException(ILLEGAL_OFFSET_OR_ILLEGAL_LENGTH);
+        }
+        return offset + length;
+    }
 }

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromByteArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromByteArray.java
@@ -17,39 +17,7 @@ import static ch.randelshofer.fastdoubleparser.ParseDigitsTaskByteArray.RECURSIO
 /**
  * Parses a {@code double} from a {@code byte} array.
  */
-final class JavaBigDecimalFromByteArray extends AbstractNumberParser {
-    public final static int MAX_INPUT_LENGTH = 1_292_782_635;
-
-    /**
-     * Threshold on the number of input characters for selecting the
-     * algorithm optimised for few digits in the significand vs. the algorithm for many
-     * digits in the significand.
-     * <p>
-     * Set this to {@link Integer#MAX_VALUE} if you only want to use
-     * the algorithm optimised for few digits in the significand.
-     * <p>
-     * Set this to {@code 0} if you only want to use the algorithm for
-     * long inputs.
-     * <p>
-     * Rationale for choosing a specific threshold value:
-     * We speculate that we only need to use the algorithm for large inputs
-     * if there is zero chance, that we can parse the input with the algorithm
-     * for small inputs.
-     * <pre>
-     * optional significant sign = 1
-     * 18 significant digits = 18
-     * optional decimal point in significant = 1
-     * optional exponent = 1
-     * optional exponent sign = 1
-     * 10 exponent digits = 10
-     * </pre>
-     */
-    public static final int MANY_DIGITS_THRESHOLD = 1 + 18 + 1 + 1 + 1 + 10;
-    private final static long MAX_EXPONENT_NUMBER = Integer.MAX_VALUE;
-    /**
-     * See {@link JavaBigDecimalParser}.
-     */
-    private final static int MAX_DIGIT_COUNT = 1_292_782_621;
+final class JavaBigDecimalFromByteArray extends AbstractBigDecimalParser {
 
     /**
      * Creates a new instance.
@@ -72,7 +40,8 @@ final class JavaBigDecimalFromByteArray extends AbstractNumberParser {
      */
     public BigDecimal parseBigDecimalString(byte[] str, int offset, int length) {
         try {
-            if (length >= MANY_DIGITS_THRESHOLD) {
+            final int endIndex = checkBigDecimalBounds(str.length, offset, length);
+            if (hasManyDigits(length)) {
                 return parseBigDecimalStringWithManyDigits(str, offset, length);
             }
             long significand = 0L;
@@ -80,7 +49,6 @@ final class JavaBigDecimalFromByteArray extends AbstractNumberParser {
             int decimalPointIndex = -1;
             final int exponentIndicatorIndex;
 
-            final int endIndex = offset + length;
             int index = offset;
             byte ch = charAt(str, index, endIndex);
             boolean illegal = false;
@@ -156,15 +124,7 @@ final class JavaBigDecimalFromByteArray extends AbstractNumberParser {
             } else {
                 exponentIndicatorIndex = endIndex;
             }
-            if (illegal || index < endIndex
-                    || digitCount == 0
-                    || digitCount > MAX_DIGIT_COUNT) {
-                throw new NumberFormatException(SYNTAX_ERROR);
-            }
-            if (exponent <= Integer.MIN_VALUE
-                    || exponent > Integer.MAX_VALUE) {
-                throw new NumberFormatException(VALUE_EXCEEDS_LIMITS);
-            }
+            checkParsedBigDecimalBounds(illegal, index, endIndex, digitCount, exponent);
 
             if (digitCount <= 18) {
                 return new BigDecimal(isNegative ? -significand : significand).scaleByPowerOfTen((int) exponent);
@@ -181,9 +141,6 @@ final class JavaBigDecimalFromByteArray extends AbstractNumberParser {
      * Parses a big decimal string that has many digits.
      */
     BigDecimal parseBigDecimalStringWithManyDigits(byte[] str, int offset, int length) {
-        if (length > MAX_INPUT_LENGTH) {
-            throw new NumberFormatException(SYNTAX_ERROR);
-        }
         final int integerPartIndex;
         final int nonZeroIntegerPartIndex;
         int decimalPointIndex = -1;
@@ -282,18 +239,9 @@ final class JavaBigDecimalFromByteArray extends AbstractNumberParser {
         } else {
             exponentIndicatorIndex = endIndex;
         }
-        if (illegal || index < endIndex) {
-            throw new NumberFormatException(SYNTAX_ERROR);
-        }
-        if (exponentIndicatorIndex - integerPartIndex == 0) {
-            throw new NumberFormatException(SYNTAX_ERROR);
-        }
-        if (exponent < Integer.MIN_VALUE
-                || exponent > Integer.MAX_VALUE
-                || digitCount > MAX_DIGIT_COUNT) {
-            throw new NumberFormatException(VALUE_EXCEEDS_LIMITS);
-        }
-        return valueOfBigDecimalString(str, nonZeroIntegerPartIndex, decimalPointIndex, nonZeroFractionalPartIndex, exponentIndicatorIndex, isNegative, (int) exponent
+        checkParsedBigDecimalBounds(illegal, index, endIndex, exponentIndicatorIndex - integerPartIndex, exponent);
+
+    return valueOfBigDecimalString(str, nonZeroIntegerPartIndex, decimalPointIndex, nonZeroFractionalPartIndex, exponentIndicatorIndex, isNegative, (int) exponent
         );
     }
 

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharSequence.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharSequence.java
@@ -17,40 +17,7 @@ import static ch.randelshofer.fastdoubleparser.ParseDigitsTaskCharSequence.RECUR
 /**
  * Parses a {@code double} from a {@code byte} array.
  */
-final class JavaBigDecimalFromCharSequence extends AbstractNumberParser {
-    public final static int MAX_INPUT_LENGTH = 1_292_782_635;
-
-
-    /**
-     * Threshold on the number of input characters for selecting the
-     * algorithm optimised for few digits in the significand vs. the algorithm for many
-     * digits in the significand.
-     * <p>
-     * Set this to {@link Integer#MAX_VALUE} if you only want to use
-     * the algorithm optimised for few digits in the significand.
-     * <p>
-     * Set this to {@code 0} if you only want to use the algorithm for
-     * long inputs.
-     * <p>
-     * Rationale for choosing a specific threshold value:
-     * We speculate that we only need to use the algorithm for large inputs
-     * if there is zero chance, that we can parse the input with the algorithm
-     * for small inputs.
-     * <pre>
-     * optional significant sign = 1
-     * 18 significant digits = 18
-     * optional decimal point in significant = 1
-     * optional exponent = 1
-     * optional exponent sign = 1
-     * 10 exponent digits = 10
-     * </pre>
-     */
-    private static final int MANY_DIGITS_THRESHOLD = 1 + 18 + 1 + 1 + 1 + 10;
-    /**
-     * See {@link JavaBigDecimalParser}.
-     */
-    private final static int MAX_DIGIT_COUNT = 1_292_782_621;
-    private final static long MAX_EXPONENT_NUMBER = Integer.MAX_VALUE;
+final class JavaBigDecimalFromCharSequence extends AbstractBigDecimalParser {
 
     /**
      * Creates a new instance.
@@ -72,7 +39,8 @@ final class JavaBigDecimalFromCharSequence extends AbstractNumberParser {
      */
     public BigDecimal parseBigDecimalString(CharSequence str, int offset, int length) {
         try {
-            if (length >= MANY_DIGITS_THRESHOLD) {
+            final int endIndex = checkBigDecimalBounds(str.length(), offset, length);
+            if (hasManyDigits(length)) {
                 return parseBigDecimalStringWithManyDigits(str, offset, length);
             }
             long significand = 0L;
@@ -80,7 +48,6 @@ final class JavaBigDecimalFromCharSequence extends AbstractNumberParser {
             int decimalPointIndex = -1;
             final int exponentIndicatorIndex;
 
-            final int endIndex = offset + length;
             int index = offset;
             char ch = charAt(str, index, endIndex);
             boolean illegal = false;
@@ -156,15 +123,7 @@ final class JavaBigDecimalFromCharSequence extends AbstractNumberParser {
             } else {
                 exponentIndicatorIndex = endIndex;
             }
-            if (illegal || index < endIndex
-                    || digitCount == 0
-                    || digitCount > MAX_DIGIT_COUNT) {
-                throw new NumberFormatException(SYNTAX_ERROR);
-            }
-            if (exponent <= Integer.MIN_VALUE
-                    || exponent > Integer.MAX_VALUE) {
-                throw new NumberFormatException(VALUE_EXCEEDS_LIMITS);
-            }
+            checkParsedBigDecimalBounds(illegal, index, endIndex, digitCount, exponent);
 
             if (digitCount <= 18) {
                 return new BigDecimal(isNegative ? -significand : significand).scaleByPowerOfTen((int) exponent);
@@ -182,9 +141,6 @@ final class JavaBigDecimalFromCharSequence extends AbstractNumberParser {
      * Parses a big decimal string that has many digits.
      */
     BigDecimal parseBigDecimalStringWithManyDigits(CharSequence str, int offset, int length) {
-        if (length > MAX_INPUT_LENGTH) {
-            throw new NumberFormatException(SYNTAX_ERROR);
-        }
         final int integerPartIndex;
         final int nonZeroIntegerPartIndex;
         int decimalPointIndex = -1;
@@ -283,17 +239,8 @@ final class JavaBigDecimalFromCharSequence extends AbstractNumberParser {
         } else {
             exponentIndicatorIndex = endIndex;
         }
-        if (illegal || index < endIndex) {
-            throw new NumberFormatException(SYNTAX_ERROR);
-        }
-        if (exponentIndicatorIndex - integerPartIndex == 0) {
-            throw new NumberFormatException(SYNTAX_ERROR);
-        }
-        if (exponent < Integer.MIN_VALUE
-                || exponent > Integer.MAX_VALUE
-                || digitCount > MAX_DIGIT_COUNT) {
-            throw new NumberFormatException(VALUE_EXCEEDS_LIMITS);
-        }
+        checkParsedBigDecimalBounds(illegal, index, endIndex, exponentIndicatorIndex - integerPartIndex, exponent);
+
         return valueOfBigDecimalString(str, nonZeroIntegerPartIndex, decimalPointIndex, nonZeroFractionalPartIndex, exponentIndicatorIndex, isNegative, (int) exponent);
     }
 

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigIntegerFromCharArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigIntegerFromCharArray.java
@@ -9,19 +9,7 @@ import java.util.Map;
 
 import static ch.randelshofer.fastdoubleparser.FastIntegerMath.fillPowersOf10Floor16;
 
-class JavaBigIntegerFromCharArray extends AbstractNumberParser {
-    public final static int MAX_INPUT_LENGTH = 1_292_782_622;
-
-    /**
-     * The resulting value must fit into {@code 2^31 - 1} bits.
-     * The decimal representation of {@code 2^31 - 1} has 646,456,993 digits.
-     */
-    private static final int MAX_DECIMAL_DIGITS = 646_456_993;
-    /**
-     * The resulting value must fit into {@code 2^31 - 1} bits.
-     * The hexadecimal representation of {@code 2^31 - 1} has 536870912 digits.
-     */
-    private static final int MAX_HEX_DIGITS = 536870912;
+class JavaBigIntegerFromCharArray extends AbstractBigIntegerParser {
 
     /**
      * Parses a {@code BigIntegerLiteral} as specified in {@link JavaBigIntegerParser}.
@@ -32,10 +20,8 @@ class JavaBigIntegerFromCharArray extends AbstractNumberParser {
     public BigInteger parseBigIntegerLiteral(char[] str, int offset, int length, int radix)
             throws NumberFormatException {
         try {
-            final int endIndex = offset + length;
-            if (offset < 0 || endIndex < offset || endIndex > str.length || length > MAX_INPUT_LENGTH) {
-                throw new IllegalArgumentException(ILLEGAL_OFFSET_OR_ILLEGAL_LENGTH);
-            }
+            final int endIndex = checkBigIntegerBounds(str.length, offset, length);
+
             // Parse optional sign
             // -------------------
             int index = offset;
@@ -65,7 +51,7 @@ class JavaBigIntegerFromCharArray extends AbstractNumberParser {
 
     private BigInteger parseDecDigits(char[] str, int from, int to, boolean isNegative) {
         int numDigits = to - from;
-        if (numDigits > 18) {
+        if (hasManyDigits(numDigits)) {
             return parseManyDecDigits(str, from, to, isNegative);
         }
         int preroll = from + (numDigits & 7);
@@ -88,9 +74,7 @@ class JavaBigIntegerFromCharArray extends AbstractNumberParser {
         if (numDigits <= 0) {
             return BigInteger.ZERO;
         }
-        if (numDigits > MAX_HEX_DIGITS) {
-            throw new NumberFormatException(VALUE_EXCEEDS_LIMITS);
-        }
+        checkHexBigIntegerBounds(numDigits);
         byte[] bytes = new byte[((numDigits + 1) >> 1) + 1];
         int index = 1;
         boolean illegalDigits = false;
@@ -125,9 +109,7 @@ class JavaBigIntegerFromCharArray extends AbstractNumberParser {
     private BigInteger parseManyDecDigits(char[] str, int from, int to, boolean isNegative) {
         from = skipZeroes(str, from, to);
         int numDigits = to - from;
-        if (numDigits > MAX_DECIMAL_DIGITS) {
-            throw new NumberFormatException(VALUE_EXCEEDS_LIMITS);
-        }
+        checkDecBigIntegerBounds(numDigits);
         Map<Integer, BigInteger> powersOfTen = fillPowersOf10Floor16(from, to);
         BigInteger result = ParseDigitsTaskCharArray.parseDigitsRecursive(str, from, to, powersOfTen);
         return isNegative ? result.negate() : result;

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigIntegerFromCharSequence.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigIntegerFromCharSequence.java
@@ -9,18 +9,8 @@ import java.util.Map;
 
 import static ch.randelshofer.fastdoubleparser.FastIntegerMath.fillPowersOf10Floor16;
 
-class JavaBigIntegerFromCharSequence extends AbstractNumberParser {
-    public final static int MAX_INPUT_LENGTH = 1_292_782_622;
-    /**
-     * The resulting value must fit into {@code 2^31 - 1} bits.
-     * The decimal representation of {@code 2^31 - 1} has 646,456,993 digits.
-     */
-    private static final int MAX_DECIMAL_DIGITS = 646_456_993;
-    /**
-     * The resulting value must fit into {@code 2^31 - 1} bits.
-     * The hexadecimal representation of {@code 2^31 - 1} has 536870912 digits.
-     */
-    private static final int MAX_HEX_DIGITS = 536870912;
+
+class JavaBigIntegerFromCharSequence extends AbstractBigIntegerParser {
 
     /**
      * Parses a {@code BigIntegerLiteral} as specified in {@link JavaBigIntegerParser}.
@@ -31,10 +21,8 @@ class JavaBigIntegerFromCharSequence extends AbstractNumberParser {
     public BigInteger parseBigIntegerLiteral(CharSequence str, int offset, int length, int radix)
             throws NumberFormatException {
         try {
-            final int endIndex = offset + length;
-            if (offset < 0 || endIndex < offset || endIndex > str.length() || length > MAX_INPUT_LENGTH) {
-                throw new IllegalArgumentException(ILLEGAL_OFFSET_OR_ILLEGAL_LENGTH);
-            }
+            final int endIndex = checkBigIntegerBounds(str.length(), offset, length);
+
             // Parse optional sign
             // -------------------
             int index = offset;
@@ -64,7 +52,7 @@ class JavaBigIntegerFromCharSequence extends AbstractNumberParser {
 
     private BigInteger parseDecDigits(CharSequence str, int from, int to, boolean isNegative) {
         int numDigits = to - from;
-        if (numDigits > 18) {
+        if (hasManyDigits(numDigits)) {
             return parseManyDecDigits(str, from, to, isNegative);
         }
         int preroll = from + (numDigits & 7);
@@ -87,9 +75,7 @@ class JavaBigIntegerFromCharSequence extends AbstractNumberParser {
         if (numDigits <= 0) {
             return BigInteger.ZERO;
         }
-        if (numDigits > MAX_HEX_DIGITS) {
-            throw new NumberFormatException(VALUE_EXCEEDS_LIMITS);
-        }
+        checkHexBigIntegerBounds(numDigits);
         byte[] bytes = new byte[((numDigits + 1) >> 1) + 1];
         int index = 1;
         boolean illegalDigits = false;
@@ -123,9 +109,7 @@ class JavaBigIntegerFromCharSequence extends AbstractNumberParser {
     private BigInteger parseManyDecDigits(CharSequence str, int from, int to, boolean isNegative) {
         from = skipZeroes(str, from, to);
         int numDigits = to - from;
-        if (numDigits > MAX_DECIMAL_DIGITS) {
-            throw new NumberFormatException(VALUE_EXCEEDS_LIMITS);
-        }
+        checkDecBigIntegerBounds(numDigits);
         Map<Integer, BigInteger> powersOfTen = fillPowersOf10Floor16(from, to);
         BigInteger result = ParseDigitsTaskCharSequence.parseDigitsRecursive(str, from, to, powersOfTen);
         return isNegative ? result.negate() : result;


### PR DESCRIPTION
It brings more clearness of input size limits.

There were places with missing checks for limits at all causing the code can behave in unexpected manner (probably throwing `ArrayOutOfBoundsException`).

It should be verified if given limits are not too high as there exists one limitation for `BigInteger` at least, which can hold `BigInteger.MAX_MAG_LENGTH` (2^25) 32-bit integers.

Many duplicated code were also removed by this change.

Existence of common checks lowers the risk of creation inadequate ones or omission them completely when adding new code.