### PR TITLE
Control characters should not be treated as whitespaces.

### DIFF
--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromByteArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromByteArray.java
@@ -25,7 +25,7 @@ abstract class AbstractJavaFloatingPointBitsFromByteArray extends AbstractFloatV
      * @return index after the optional white space
      */
     private static int skipWhitespace(byte[] str, int index, int endIndex) {
-        while (index < endIndex && (str[index] & 0xff) <= ' ') {
+        while (index < endIndex && (str[index] == ' ')) {
             index++;
         }
         return index;

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromCharArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromCharArray.java
@@ -28,7 +28,7 @@ abstract class AbstractJavaFloatingPointBitsFromCharArray extends AbstractFloatV
      * @return index after the optional white space
      */
     private static int skipWhitespace(char[] str, int index, int endIndex) {
-        while (index < endIndex && str[index] <= ' ') {
+        while (index < endIndex && str[index] == ' ') {
             index++;
         }
         return index;

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromCharSequence.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromCharSequence.java
@@ -25,7 +25,7 @@ abstract class AbstractJavaFloatingPointBitsFromCharSequence extends AbstractFlo
      * @return index after the optional white space
      */
     private static int skipWhitespace(CharSequence str, int index, int endIndex) {
-        while (index < endIndex && str.charAt(index) <= ' ') {
+        while (index < endIndex && str.charAt(index) == ' ') {
             index++;
         }
         return index;

--- a/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/AbstractJavaFloatParserTest.java
+++ b/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/AbstractJavaFloatParserTest.java
@@ -70,7 +70,8 @@ public abstract class AbstractJavaFloatParserTest extends AbstractFloatValuePars
                 new NumberTestData("cafebabe.1p2"),
                 new NumberTestData("0x123pa"),
                 new NumberTestData("0x1.2e7"),
-                new NumberTestData("0xp89")
+                new NumberTestData("0xp89"),
+                new NumberTestData("\u001f12\u001f")
         );
     }
 


### PR DESCRIPTION
The only character, which should be considered in the context as white space character is space itself, do I have right?