### PR TITLE
More efficient computation of splitting point for recursive parsing.

### DIFF
--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastIntegerMath.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastIntegerMath.java
@@ -129,7 +129,7 @@ class FastIntegerMath {
             return;
         }
         // recursion case:
-        int mid = splitFloor16(from, to);
+        int mid = splitFloor16(numDigits, to);
         int n = to - mid;
         if (!powersOfTen.containsKey(n)) {
             fillPowersOfNFloor16Recursive(powersOfTen, from, mid);
@@ -156,10 +156,16 @@ class FastIntegerMath {
         return new UInt128(Math.unsignedMultiplyHigh(x, y), x * y);
     }
 
-    static int splitFloor16(int from, int to) {
-        int mid = (from + to) >>> 1;// split in half
-        mid = to - (((to - mid + 15) >> 4) << 4);// make numDigits of low a multiple of 16
-        return mid;
+    /** Finds middle of range with upper range half rounded up to multiple of 16.
+     *
+     * @param length interval length
+     * @param to interval end
+     * @return middle of range with upper range half rounded up to multiple of 16
+     */
+    static int splitFloor16(int length, int to) {
+        // divide length by 2 as we want the middle, round up range half to multiples of 16
+        int range = (((length + 31) >>> 5) << 4);
+        return to - range;
     }
 
     static class UInt128 {

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/ParseDigitsTaskByteArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/ParseDigitsTaskByteArray.java
@@ -74,7 +74,7 @@ class ParseDigitsTaskByteArray {
         }
 
         // Recursion case: Split large sequences up into two parts. The lower part is a multiple of 16 digits.
-        int mid = splitFloor16(from, to);
+        int mid = splitFloor16(numDigits, to);
         BigInteger high = parseDigitsRecursive(str, from, mid, powersOfTen);
         BigInteger low = parseDigitsRecursive(str, mid, to, powersOfTen);
 

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/ParseDigitsTaskCharArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/ParseDigitsTaskCharArray.java
@@ -75,7 +75,7 @@ class ParseDigitsTaskCharArray {
         }
 
         // Recursion case: Split large sequences up into two parts. The lower part is a multiple of 16 digits.
-        int mid = splitFloor16(from, to);
+        int mid = splitFloor16(numDigits, to);
         BigInteger high = parseDigitsRecursive(str, from, mid, powersOfTen);
         BigInteger low = parseDigitsRecursive(str, mid, to, powersOfTen);
 

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/ParseDigitsTaskCharSequence.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/ParseDigitsTaskCharSequence.java
@@ -76,7 +76,7 @@ class ParseDigitsTaskCharSequence {
         }
 
         // Recursion case: Split large sequences up into two parts. The lower part is a multiple of 16 digits.
-        int mid = splitFloor16(from, to);
+        int mid = splitFloor16(numDigits, to);
         BigInteger high = parseDigitsRecursive(str, from, mid, powersOfTen);
         BigInteger low = parseDigitsRecursive(str, mid, to, powersOfTen);
 

--- a/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/FastIntegerMathTest.java
+++ b/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/FastIntegerMathTest.java
@@ -4,9 +4,15 @@
  */
 package ch.randelshofer.fastdoubleparser;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FastIntegerMathTest {
     @Test
@@ -19,4 +25,47 @@ public class FastIntegerMathTest {
         assertEquals(0x123456789abcdeeeL, actual.high);
         assertEquals(0xdcba987654321100L, actual.low);
     }
+
+    private static Stream<Arguments> splitFloor16testData() {
+        return Stream.of(// from, to, expectedMid
+                Arguments.of(0, 0, 0),
+                Arguments.of(0, 16, 0),
+                Arguments.of(10, 30, 14),
+                Arguments.of(0, 32, 16),
+                Arguments.of(10, 40, 24),
+                Arguments.of(0, 100, 36),
+                Arguments.of(1, 101, 37)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("splitFloor16testData")
+    void splitFloor16specialValues(int from, int to, int expectedMid) {
+        assert (to - expectedMid) % 16 == 0;
+        assert expectedMid <= from + (to - from) / 2;
+        assert expectedMid >= from + (to - from) / 2 - 15;
+
+        assertEquals(expectedMid, FastIntegerMath.splitFloor16(to - from, to));
+    }
+
+    @Test
+    void splitFloor16() {
+        for (int from = 0; from < 50; from++) {
+            for (int to = from; to < 100; to++) {
+                int actual = FastIntegerMath.splitFloor16(to - from, to);
+                assertEquals(0, (to - actual) % 16);
+                assertTrue(actual <= from + (to - from) / 2);
+                assertTrue(actual >= from + (to - from) / 2 - 15);
+
+                assertEquals(oldSplitFloor16(from, to), actual);
+            }
+        }
+    }
+
+    static int oldSplitFloor16(int from, int to) {
+        int mid = (from + to) >>> 1;// split in half
+        mid = to - (((to - mid + 15) >> 4) << 4);// make numDigits of low a multiple of 16
+        return mid;
+    }
+
 }

--- a/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/JmhSplitFloor16.java
+++ b/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/JmhSplitFloor16.java
@@ -1,0 +1,51 @@
+/*
+ * @(#)JmhSplitFloor16.java
+ * Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+ */
+package ch.randelshofer.fastdoubleparser;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(value = 1)
+@Measurement(iterations = 2, time = 1)
+@Warmup(iterations = 2, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class JmhSplitFloor16 {
+    private static final int TO_MAX = 1024 + 1;
+    private static final int FROM_MAX = 100;
+    private static final int DATA_LENGTH = TO_MAX - FROM_MAX;
+
+    @Benchmark
+    @OperationsPerInvocation(DATA_LENGTH)
+    public void oldSplitFloor16(Blackhole blackhole) {
+        for (int i = 0; i < FROM_MAX; i++) {
+            for (int j = i; j < TO_MAX; j++) {
+                blackhole.consume(FastIntegerMathTest.oldSplitFloor16(i, j));
+            }
+        }
+    }
+    @Benchmark
+    @OperationsPerInvocation(DATA_LENGTH)
+    public void splitFloor16(Blackhole blackhole) {
+        for (int i = 0; i < FROM_MAX; i++) {
+            for (int j = i; j < TO_MAX; j++) {
+                blackhole.consume(FastIntegerMath.splitFloor16(i, j));
+            }
+        }
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(JmhSplitFloor16.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
Some [error](https://github.com/xtonik/FastDoubleParser/actions/runs/5160512525) occurs in Github CI build, but I can't easily imagine what is the reason.