### PR TITLE
Introduction caching FFT of powers of ten.

### DIFF
--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastIntegerMath.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastIntegerMath.java
@@ -57,7 +57,7 @@ class FastIntegerMath {
             if (floorN == n) {
                 return floorEntry.getValue();
             } else {
-                return FftMultiplier.multiply(floorEntry.getValue(), computePowerOfTen(powersOfTen, n - floorN));
+                return FftMultiplier.multiply(floorEntry.getValue(), computePowerOfTen(powersOfTen, n - floorN), n - floorN);
             }
         }
         return FIVE.pow(n).shiftLeft(n);
@@ -80,7 +80,7 @@ class FastIntegerMath {
             diffValue = computeTenRaisedByNFloor16Recursive(powersOfTen, diff);
             powersOfTen.put(diff, diffValue);
         }
-        return FftMultiplier.multiply(floorValue, diffValue);
+        return FftMultiplier.multiply(floorValue, diffValue, diff);
     }
 
     static NavigableMap<Integer, BigInteger> createPowersOfTenFloor16Map() {

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FftMultiplier.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FftMultiplier.java
@@ -64,13 +64,13 @@ class FftMultiplier {
      * elements representing all (2^(k+2))-th roots between 0 and pi/2.
      * Used for FFT multiplication.
      */
-    private volatile static ComplexVector[] ROOTS2_CACHE = new ComplexVector[ROOTS2_CACHE_SIZE];
+    private final static AtomicReferenceArray<ComplexVector> ROOTS2_CACHE = new AtomicReferenceArray<>(ROOTS_CACHE2_SIZE);
     /**
      * Sets of complex roots of unity. The set at index k contains 3*2^k
      * elements representing all (3*2^(k+2))-th roots between 0 and pi/2.
      * Used for FFT multiplication.
      */
-    private volatile static ComplexVector[] ROOTS3_CACHE = new ComplexVector[ROOTS3_CACHE_SIZE];
+    private final static AtomicReferenceArray<ComplexVector> ROOTS3_CACHE = new AtomicReferenceArray<>(ROOTS3_CACHE_SIZE);
 
     /**
      * Returns the maximum number of bits that one double precision number can fit without
@@ -358,10 +358,10 @@ class FftMultiplier {
         ComplexVector[] roots = new ComplexVector[logN + 1];
         for (int i = logN; i >= 0; i -= 2) {
             if (i < ROOTS_CACHE2_SIZE) {
-                if (ROOTS2_CACHE[i] == null) {
-                    ROOTS2_CACHE[i] = calculateRootsOfUnity(1 << i);
+                if (ROOTS2_CACHE.get(i) == null) {
+                    ROOTS2_CACHE.set(i, calculateRootsOfUnity(1 << i));
                 }
-                roots[i] = ROOTS2_CACHE[i];
+                roots[i] = ROOTS2_CACHE.get(i);
             } else {
                 roots[i] = calculateRootsOfUnity(1 << i);
             }
@@ -377,10 +377,10 @@ class FftMultiplier {
      */
     private static ComplexVector getRootsOfUnity3(int logN) {
         if (logN < ROOTS3_CACHE_SIZE) {
-            if (ROOTS3_CACHE[logN] == null) {
-                ROOTS3_CACHE[logN] = calculateRootsOfUnity(3 << logN);
+            if (ROOTS3_CACHE.get(logN) == null) {
+                ROOTS3_CACHE.set(logN, calculateRootsOfUnity(3 << logN));
             }
-            return ROOTS3_CACHE[logN];
+            return ROOTS3_CACHE.get(logN);
         } else {
             return calculateRootsOfUnity(3 << logN);
         }

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FftMultiplier.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FftMultiplier.java
@@ -701,29 +701,27 @@ class FftMultiplier {
         // Use a 2^n or 3*2^n transform, whichever is shorter
         int fftLen2 = 1 << (logFFTLen);   // rounded to 2^n
         int fftLen3 = fftLen2 * 3 / 4;   // rounded to 3*2^n
+        ComplexVector vec, weights;
         if (fftLen < fftLen3) {
-            fftLen = fftLen3;
-            ComplexVector vec = toFftVector(mag, fftLen, bitsPerPoint);
+            vec = toFftVector(mag, fftLen3, bitsPerPoint);
             ComplexVector[] roots2 = getRootsOfUnity2(logFFTLen - 2);   // roots for length fftLen/3 which is a power of two
-            ComplexVector weights = getRootsOfUnity3(logFFTLen - 2);
             ComplexVector twiddles = getRootsOfUnity3(logFFTLen - 4);
+            weights = getRootsOfUnity3(logFFTLen - 2);
             vec.applyWeights(weights);
             fftMixedRadix(vec, roots2, twiddles);
             vec.squarePointwise();
             ifftMixedRadix(vec, roots2, twiddles);
-            vec.applyInverseWeights(weights);
-            return fromFftVector(vec, 1, bitsPerPoint);
         } else {
-            fftLen = fftLen2;
-            ComplexVector vec = toFftVector(mag, fftLen, bitsPerPoint);
-            ComplexVector[] roots = getRootsOfUnity2(logFFTLen);
-            vec.applyWeights(roots[logFFTLen]);
-            fft(vec, roots);
+            vec = toFftVector(mag, fftLen2, bitsPerPoint);
+            ComplexVector[] roots2 = getRootsOfUnity2(logFFTLen);
+            weights = roots2[logFFTLen];
+            vec.applyWeights(weights);
+            fft(vec, roots2);
             vec.squarePointwise();
-            ifft(vec, roots);
-            vec.applyInverseWeights(roots[logFFTLen]);
-            return fromFftVector(vec, 1, bitsPerPoint);
+            ifft(vec, roots2);
         }
+        vec.applyInverseWeights(weights);
+        return fromFftVector(vec, 1, bitsPerPoint);
     }
 
     /**

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FftMultiplier.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FftMultiplier.java
@@ -5,8 +5,9 @@
 package ch.randelshofer.fastdoubleparser;
 
 import java.math.BigInteger;
-import java.util.NavigableMap;
-import java.util.TreeMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import static ch.randelshofer.fastdoubleparser.FastDoubleSwar.fma;
 
@@ -51,8 +52,8 @@ class FftMultiplier {
      */
     static final int ROOTS2_CACHE_SIZE = 20;
 
-    private static final NavigableMap<Long, ComplexVector> FFT_POWER_OF_TEN_CACHE2 = new TreeMap<>();
-    private static final NavigableMap<Long, ComplexVector> FFT_POWER_OF_TEN_CACHE3 = new TreeMap<>();
+    private static final Map<Long, ComplexVector> FFT_POWER_OF_TEN_CACHE2 = new ConcurrentHashMap<>();
+    private static final Map<Long, ComplexVector> FFT_POWER_OF_TEN_CACHE3 = new ConcurrentHashMap<>();
 
 
     /**
@@ -64,7 +65,7 @@ class FftMultiplier {
      * elements representing all (2^(k+2))-th roots between 0 and pi/2.
      * Used for FFT multiplication.
      */
-    private final static AtomicReferenceArray<ComplexVector> ROOTS2_CACHE = new AtomicReferenceArray<>(ROOTS_CACHE2_SIZE);
+    private final static AtomicReferenceArray<ComplexVector> ROOTS2_CACHE = new AtomicReferenceArray<>(ROOTS2_CACHE_SIZE);
     /**
      * Sets of complex roots of unity. The set at index k contains 3*2^k
      * elements representing all (3*2^(k+2))-th roots between 0 and pi/2.
@@ -357,7 +358,7 @@ class FftMultiplier {
     private static ComplexVector[] getRootsOfUnity2(int logN) {
         ComplexVector[] roots = new ComplexVector[logN + 1];
         for (int i = logN; i >= 0; i -= 2) {
-            if (i < ROOTS_CACHE2_SIZE) {
+            if (i < ROOTS2_CACHE_SIZE) {
                 if (ROOTS2_CACHE.get(i) == null) {
                     ROOTS2_CACHE.set(i, calculateRootsOfUnity(1 << i));
                 }

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromByteArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromByteArray.java
@@ -364,7 +364,7 @@ final class JavaBigDecimalFromByteArray extends AbstractNumberParser {
                 significand = fractionalPart;
             } else {
                 BigInteger integerFactor = computePowerOfTen(powersOfTen, fractionDigitsCount);
-                significand = FftMultiplier.multiply(integerPart, integerFactor).add(fractionalPart);
+                significand = FftMultiplier.multiply(integerPart, integerFactor, fractionDigitsCount).add(fractionalPart);
             }
         } else {
             significand = integerPart;

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharArray.java
@@ -363,7 +363,7 @@ final class JavaBigDecimalFromCharArray extends AbstractNumberParser {
                 significand = fractionalPart;
             } else {
                 BigInteger integerFactor = computePowerOfTen(powersOfTen, integerExponent);
-                significand = FftMultiplier.multiply(integerPart, integerFactor).add(fractionalPart);
+                significand = FftMultiplier.multiply(integerPart, integerFactor, integerExponent).add(fractionalPart);
             }
         } else {
             significand = integerPart;

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharSequence.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharSequence.java
@@ -363,7 +363,7 @@ final class JavaBigDecimalFromCharSequence extends AbstractNumberParser {
                 significand = fractionalPart;
             } else {
                 BigInteger integerFactor = computePowerOfTen(powersOfTen, fractionDigitsCount);
-                significand = FftMultiplier.multiply(integerPart, integerFactor).add(fractionalPart);
+                significand = FftMultiplier.multiply(integerPart, integerFactor, fractionDigitsCount).add(fractionalPart);
             }
         } else {
             significand = integerPart;

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/ParseDigitsTaskByteArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/ParseDigitsTaskByteArray.java
@@ -78,8 +78,7 @@ class ParseDigitsTaskByteArray {
         BigInteger high = parseDigitsRecursive(str, from, mid, powersOfTen);
         BigInteger low = parseDigitsRecursive(str, mid, to, powersOfTen);
 
-        //high = high.multiply(powersOfTen.get(to - mid));
-        high = FftMultiplier.multiply(high, powersOfTen.get(to - mid));
+        high = FftMultiplier.multiply(high, powersOfTen.get(to - mid), to - mid);
         return low.add(high);
     }
 }

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/ParseDigitsTaskCharArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/ParseDigitsTaskCharArray.java
@@ -79,7 +79,7 @@ class ParseDigitsTaskCharArray {
         BigInteger high = parseDigitsRecursive(str, from, mid, powersOfTen);
         BigInteger low = parseDigitsRecursive(str, mid, to, powersOfTen);
 
-        high = FftMultiplier.multiply(high, powersOfTen.get(to - mid));
+        high = FftMultiplier.multiply(high, powersOfTen.get(to - mid), to - mid);
         return low.add(high);
     }
 }

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/ParseDigitsTaskCharSequence.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/ParseDigitsTaskCharSequence.java
@@ -80,8 +80,7 @@ class ParseDigitsTaskCharSequence {
         BigInteger high = parseDigitsRecursive(str, from, mid, powersOfTen);
         BigInteger low = parseDigitsRecursive(str, mid, to, powersOfTen);
 
-        //high = high.multiply(powersOfTen.get(to - mid));
-        high = FftMultiplier.multiply(high, powersOfTen.get(to - mid));
+        high = FftMultiplier.multiply(high, powersOfTen.get(to - mid), to - mid);
         return low.add(high);
     }
 }


### PR DESCRIPTION
Caching FFT of powers of ten improves performance as they can be reused during computation.

Some memory is wasted as the cache is permanent, but the same situation stands with existing cache of powers of ten or roots of unity.

More comprehensive solution should be considered allowing user to control the cache  - what to store, how long, forcing flush etc.