### PR TITLE
Bug: the highest bit of hexadecimal float significand ignored

### DIFF
--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleMath.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastDoubleMath.java
@@ -971,7 +971,7 @@ class FastDoubleMath {
             // Convert the significand into a double.
             // The cast will round the significand if necessary.
             // We use Math.abs here, because we treat the significand as an unsigned long.
-            double d = Math.abs((double) significand);
+            double d = Math.abs((double) significand);// FIXME highest bit ignored
 
             // Scale the significand by the power.
             // This only works if power is within the supported range, so that

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastFloatMath.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastFloatMath.java
@@ -86,7 +86,7 @@ class FastFloatMath {
             // Convert the significand into a float.
             // The cast will round the significand if necessary.
             // We use Math.abs here, because we treat the significand as an unsigned long.
-            float d = Math.abs((float) significand);
+            float d = Math.abs((float) significand); // FIXME highest bit ignored
 
             // Scale the significand by the power.
             // This only works if power is within the supported range, so that

--- a/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/AbstractJavaDoubleParserTest.java
+++ b/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/AbstractJavaDoubleParserTest.java
@@ -162,8 +162,56 @@ public abstract class AbstractJavaDoubleParserTest extends AbstractFloatValuePar
                 new NumberTestData("0x1.234567890abcdefP123", 0x1.234567890abcdefp123),
                 new NumberTestData("+0x1234567890.abcdefp-45", 0x1234567890.abcdefp-45d),
                 new NumberTestData("0x1234567890.abcdef12p-45", 0x1234567890.abcdef12p-45),
-                new NumberTestData("0x1234567890abcdef1234567890abcdef1234567890abcdef.1234567890abcdefp-45", 0x1234567890abcdef1234567890abcdef1234567890abcdef.1234567890abcdefp-45)
+                new NumberTestData("0x1234567890abcdef1234567890abcdef1234567890abcdef.1234567890abcdefp-45", 0x1234567890abcdef1234567890abcdef1234567890abcdef.1234567890abcdefp-45),
 
+                new NumberTestData("0x8000000000000000p0", 0x8000000000000000p0),
+                new NumberTestData("0x8000000000000000p10", 0x8000000000000000p10),
+                new NumberTestData("0x8000000000000000p-10", 0x8000000000000000p-10),
+                new NumberTestData("-0x8000000000000000p0", -0x8000000000000000p0),
+                new NumberTestData("-0x8000000000000000p10", -0x8000000000000000p10),
+                new NumberTestData("-0x8000000000000000p-10", -0x8000000000000000p-10),
+
+                new NumberTestData("0xffffffffffffffffp0", 0xffffffffffffffffp0),
+                new NumberTestData("0xffffffffffffffffp10", 0xffffffffffffffffp10),
+                new NumberTestData("0xffffffffffffffffp-10", 0xffffffffffffffffp-10),
+                new NumberTestData("-0xffffffffffffffffp0", -0xffffffffffffffffp0),
+                new NumberTestData("-0xffffffffffffffffp10", -0xffffffffffffffffp10),
+                new NumberTestData("-0xffffffffffffffffp-10", -0xffffffffffffffffp-10),
+
+                new NumberTestData("0xfeeeeeeeeeeeeeeep0", 0xfeeeeeeeeeeeeeeep0),
+                new NumberTestData("0xfeeeeeeeeeeeeeeep10", 0xfeeeeeeeeeeeeeeep10),
+                new NumberTestData("0xfeeeeeeeeeeeeeeep-10", 0xfeeeeeeeeeeeeeeep-10),
+                new NumberTestData("-0xfeeeeeeeeeeeeeecp0", -0xfeeeeeeeeeeeeeecp0),
+                new NumberTestData("-0xfeeeeeeeeeeeeeecp10", -0xfeeeeeeeeeeeeeecp10),
+                new NumberTestData("-0xfeeeeeeeeeeeeeecp-10", -0xfeeeeeeeeeeeeeecp-10),
+
+                new NumberTestData("0xfddddddddddddddddp0", 0xfddddddddddddddddp0),
+                new NumberTestData("0xfddddddddddddddddp10", 0xfddddddddddddddddp10),
+                new NumberTestData("0xfddddddddddddddddp-10", 0xfddddddddddddddddp-10),
+                new NumberTestData("-0xfddddddddddddddddp0", -0xfddddddddddddddddp0),
+                new NumberTestData("-0xfddddddddddddddddp10", -0xfddddddddddddddddp10),
+                new NumberTestData("-0xfddddddddddddddddp-10", -0xfddddddddddddddddp-10),
+
+                new NumberTestData("0xfeeeef0000000000p0", 0xfeeeef0000000000p0),
+                new NumberTestData("0xfeeeef0000000000p10", 0xfeeeef0000000000p10),
+                new NumberTestData("0xfeeeef0000000000p-10", 0xfeeeef0000000000p-10),
+                new NumberTestData("-0xfeeeef0000000000p0", -0xfeeeef0000000000p0),
+                new NumberTestData("-0xfeeeef0000000000p10", -0xfeeeef0000000000p10),
+                new NumberTestData("-0xfeeeef0000000000p-10", -0xfeeeef0000000000p-10),
+
+                new NumberTestData("0xfeeeee0000000000p0", 0xfeeeee0000000000p0),
+                new NumberTestData("0xfeeeee0000000000p10", 0xfeeeee0000000000p10),
+                new NumberTestData("0xfeeeee0000000000p-10", 0xfeeeee0000000000p-10),
+                new NumberTestData("-0xfeeeee0000000000p0", -0xfeeeee0000000000p0),
+                new NumberTestData("-0xfeeeee0000000000p10", -0xfeeeee0000000000p10),
+                new NumberTestData("-0xfeeeee0000000000p-10", -0xfeeeee0000000000p-10),
+
+                new NumberTestData("0xeeeeee0000000000p0", 0xeeeeee0000000000p0),
+                new NumberTestData("0xeeeeee0000000000p10", 0xeeeeee0000000000p10),
+                new NumberTestData("0xeeeeee0000000000p-10", 0xeeeeee0000000000p-10),
+                new NumberTestData("-0xeeeeee0000000000p0", -0xeeeeee0000000000p0),
+                new NumberTestData("-0xeeeeee0000000000p10", -0xeeeeee0000000000p10),
+                new NumberTestData("-0xeeeeee0000000000p-10", -0xeeeeee0000000000p-10)
         );
     }
 

--- a/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/AbstractJavaFloatParserTest.java
+++ b/fastdoubleparser-dev/src/test/java/ch/randelshofer/fastdoubleparser/AbstractJavaFloatParserTest.java
@@ -162,7 +162,49 @@ public abstract class AbstractJavaFloatParserTest extends AbstractFloatValuePars
                 new NumberTestData("+0x1234567890.abcdefp-45", 0x1234567890.abcdefp-45f),
                 new NumberTestData("0x1234567890.abcdef1p-45", 0x1234567890.abcdef1p-45f),
                 new NumberTestData("0x1234567890.abcdef12p-45", 0x1234567890.abcdef12p-45f),
-                new NumberTestData("0x1234567890abcdef1234567890abcdef1234567890abcdef.1234567890abcdefp-45", Float.POSITIVE_INFINITY)
+                new NumberTestData("0x1234567890abcdef1234567890abcdef1234567890abcdef.1234567890abcdefp-45", Float.POSITIVE_INFINITY),
+
+                new NumberTestData("0x8000000000000000p0", 0x8000000000000000p0f),
+                new NumberTestData("0x8000000000000000p10", 0x8000000000000000p10f),
+                new NumberTestData("0x8000000000000000p-10", 0x8000000000000000p-10f),
+                new NumberTestData("-0x8000000000000000p0", -0x8000000000000000p0f),
+                new NumberTestData("-0x8000000000000000p10", -0x8000000000000000p10f),
+                new NumberTestData("-0x8000000000000000p-10", -0x8000000000000000p-10f),
+
+                new NumberTestData("0xffffffffffffffffp0", 0xffffffffffffffffp0f),
+                new NumberTestData("0xffffffffffffffffp10", 0xffffffffffffffffp10f),
+                new NumberTestData("0xffffffffffffffffp-10", 0xffffffffffffffffp-10f),
+                new NumberTestData("-0xffffffffffffffffp0", -0xffffffffffffffffp0f),
+                new NumberTestData("-0xffffffffffffffffp10", -0xffffffffffffffffp10f),
+                new NumberTestData("-0xffffffffffffffffp-10", -0xffffffffffffffffp-10f),
+
+                new NumberTestData("0xfeeeeeeeeeeeeeeep0", 0xfeeeeeeeeeeeeeeep0f),
+                new NumberTestData("0xfeeeeeeeeeeeeeeep10", 0xfeeeeeeeeeeeeeeep10f),
+                new NumberTestData("0xfeeeeeeeeeeeeeeep-10", 0xfeeeeeeeeeeeeeeep-10f),
+                new NumberTestData("-0xfeeeeeeeeeeeeeecp0", -0xfeeeeeeeeeeeeeecp0f),
+                new NumberTestData("-0xfeeeeeeeeeeeeeecp10", -0xfeeeeeeeeeeeeeecp10f),
+                new NumberTestData("-0xfeeeeeeeeeeeeeecp-10", -0xfeeeeeeeeeeeeeecp-10f),
+
+                new NumberTestData("0xfddddddddddddddddp0", 0xfddddddddddddddddp0f),
+                new NumberTestData("0xfddddddddddddddddp10", 0xfddddddddddddddddp10f),
+                new NumberTestData("0xfddddddddddddddddp-10", 0xfddddddddddddddddp-10f),
+                new NumberTestData("-0xfddddddddddddddddp0", -0xfddddddddddddddddp0f),
+                new NumberTestData("-0xfddddddddddddddddp10", -0xfddddddddddddddddp10f),
+                new NumberTestData("-0xfddddddddddddddddp-10", -0xfddddddddddddddddp-10f),
+
+                new NumberTestData("0xfeeeef0000000000p0", 0xfeeeef0000000000p0f),
+                new NumberTestData("0xfeeeef0000000000p10", 0xfeeeef0000000000p10f),
+                new NumberTestData("0xfeeeef0000000000p-10", 0xfeeeef0000000000p-10f),
+                new NumberTestData("-0xfeeeef0000000000p0", -0xfeeeef0000000000p0f),
+                new NumberTestData("-0xfeeeef0000000000p10", -0xfeeeef0000000000p10f),
+                new NumberTestData("-0xfeeeef0000000000p-10", -0xfeeeef0000000000p-10f),
+
+                new NumberTestData("0xfeeeee0000000000p0", 0xfeeeee0000000000p0f),
+                new NumberTestData("0xfeeeee0000000000p10", 0xfeeeee0000000000p10f),
+                new NumberTestData("0xfeeeee0000000000p-10", 0xfeeeee0000000000p-10f),
+                new NumberTestData("-0xfeeeee0000000000p0", -0xfeeeee0000000000p0f),
+                new NumberTestData("-0xfeeeee0000000000p10", -0xfeeeee0000000000p10f),
+                new NumberTestData("-0xfeeeee0000000000p-10", -0xfeeeee0000000000p-10f),
 
         );
     }


### PR DESCRIPTION
It seems that the code is written as the significand sign is not taken in the manner at all, but it should.

Related source code lines are changed by already created [merge request](https://github.com/wrandelshofer/FastDoubleParser/pull/47).

More test cases created than necessary, they should be filtered before merge.