### PR TITLE
Multiply by power of 5 and then shift left

### DIFF
--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastIntegerMath.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FastIntegerMath.java
@@ -7,10 +7,16 @@ package ch.randelshofer.fastdoubleparser;
 import java.math.BigInteger;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.TreeMap;
 
 class FastIntegerMath {
+
+    private static final int USE_POWER_OF_FIVE_AND_SHIFT_MIN_THRESHOLD = 800; // stated by benchmark results
+
+    private static final int USE_POWER_OF_FIVE_AND_SHIFT_MAX_THRESHOLD = FftMultiplier.FFT_THRESHOLD;
+
     public static final BigInteger FIVE = BigInteger.valueOf(5);
     final static BigInteger TEN_POW_16 = BigInteger.valueOf(10_000_000_000_000_000L);
     final static BigInteger FIVE_POW_16 = BigInteger.valueOf(152_587_890_625L);
@@ -89,6 +95,22 @@ class FastIntegerMath {
         powersOfTen.put(0, BigInteger.ONE);
         powersOfTen.put(16, TEN_POW_16);
         return powersOfTen;
+    }
+    static boolean usePowerOfFiveAndShift(int n) {
+        return n > USE_POWER_OF_FIVE_AND_SHIFT_MIN_THRESHOLD && n < USE_POWER_OF_FIVE_AND_SHIFT_MAX_THRESHOLD;
+    }
+
+    static Map<Integer, BigInteger> createPowersOfFive(Map<Integer, BigInteger> powersOfTen) {
+        Map<Integer, BigInteger> powersOfFive = new TreeMap<>();
+        for (Entry<Integer, BigInteger> entry : powersOfTen.entrySet()) {
+            int exponent = entry.getKey();
+            if (usePowerOfFiveAndShift(exponent)) {
+                BigInteger powerOfTen = entry.getValue();
+                BigInteger powerOfFive = powerOfTen.shiftRight(exponent);
+                powersOfFive.put(exponent, powerOfFive);
+            }
+        }
+        return powersOfFive;
     }
 
     public static long estimateNumBits(long numDecimalDigits) {

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FftMultiplier.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FftMultiplier.java
@@ -34,7 +34,7 @@ class FftMultiplier {
      * the mag arrays is greater than this threshold, then FFT
      * multiplication will be used.
      */
-    private static final int FFT_THRESHOLD = 33220;
+    static final int FFT_THRESHOLD = 33220;
     /**
      * This constant limits {@code mag.length} of BigIntegers to the supported
      * range.

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharArray.java
@@ -6,6 +6,7 @@ package ch.randelshofer.fastdoubleparser;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Map;
 import java.util.NavigableMap;
 
 import static ch.randelshofer.fastdoubleparser.FastIntegerMath.*;
@@ -271,6 +272,7 @@ final class JavaBigDecimalFromCharArray extends AbstractBigDecimalParser {
         int fractionDigitsCount = exponentIndicatorIndex - nonZeroFractionalPartIndex;
         int integerDigitsCount = decimalPointIndex - integerPartIndex;
         NavigableMap<Integer, BigInteger> powersOfTen = null;
+        Map<Integer, BigInteger> powersOfFive;
 
         // Parse the significand
         // ---------------------
@@ -283,9 +285,10 @@ final class JavaBigDecimalFromCharArray extends AbstractBigDecimalParser {
             if (integerDigitsCount > RECURSION_THRESHOLD) {
                 powersOfTen = createPowersOfTenFloor16Map();
                 fillPowersOfNFloor16Recursive(powersOfTen, integerPartIndex, decimalPointIndex);
-                integerPart = ParseDigitsTaskCharArray.parseDigitsRecursive(str, integerPartIndex, decimalPointIndex, powersOfTen);
+                powersOfFive = createPowersOfFive(powersOfTen);
+                integerPart = ParseDigitsTaskCharArray.parseDigitsRecursive(str, integerPartIndex, decimalPointIndex, powersOfTen, powersOfFive);
             } else {
-                integerPart = ParseDigitsTaskCharArray.parseDigitsRecursive(str, integerPartIndex, decimalPointIndex, null);
+                integerPart = ParseDigitsTaskCharArray.parseDigitsRecursive(str, integerPartIndex, decimalPointIndex, null, null);
             }
         } else {
             integerPart = BigInteger.ZERO;
@@ -300,9 +303,10 @@ final class JavaBigDecimalFromCharArray extends AbstractBigDecimalParser {
                     powersOfTen = createPowersOfTenFloor16Map();
                 }
                 fillPowersOfNFloor16Recursive(powersOfTen, decimalPointIndex + 1, exponentIndicatorIndex);
-                fractionalPart = ParseDigitsTaskCharArray.parseDigitsRecursive(str, decimalPointIndex + 1, exponentIndicatorIndex, powersOfTen);
+                powersOfFive = createPowersOfFive(powersOfTen);
+                fractionalPart = ParseDigitsTaskCharArray.parseDigitsRecursive(str, decimalPointIndex + 1, exponentIndicatorIndex, powersOfTen, powersOfFive);
             } else {
-                fractionalPart = ParseDigitsTaskCharArray.parseDigitsRecursive(str, decimalPointIndex + 1, exponentIndicatorIndex, null);
+                fractionalPart = ParseDigitsTaskCharArray.parseDigitsRecursive(str, decimalPointIndex + 1, exponentIndicatorIndex, null, null);
             }
             // If the integer part is not 0, we combine it with the fraction part.
             if (integerPart.signum() == 0) {

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigIntegerFromCharArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigIntegerFromCharArray.java
@@ -7,6 +7,7 @@ package ch.randelshofer.fastdoubleparser;
 import java.math.BigInteger;
 import java.util.Map;
 
+import static ch.randelshofer.fastdoubleparser.FastIntegerMath.createPowersOfFive;
 import static ch.randelshofer.fastdoubleparser.FastIntegerMath.fillPowersOf10Floor16;
 
 class JavaBigIntegerFromCharArray extends AbstractBigIntegerParser {
@@ -111,7 +112,8 @@ class JavaBigIntegerFromCharArray extends AbstractBigIntegerParser {
         int numDigits = to - from;
         checkDecBigIntegerBounds(numDigits);
         Map<Integer, BigInteger> powersOfTen = fillPowersOf10Floor16(from, to);
-        BigInteger result = ParseDigitsTaskCharArray.parseDigitsRecursive(str, from, to, powersOfTen);
+        Map<Integer, BigInteger> powersOfFive = createPowersOfFive(powersOfTen);
+        BigInteger result = ParseDigitsTaskCharArray.parseDigitsRecursive(str, from, to, powersOfTen, powersOfFive);
         return isNegative ? result.negate() : result;
     }
 

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/ParseDigitsTaskCharArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/ParseDigitsTaskCharArray.java
@@ -66,7 +66,7 @@ class ParseDigitsTaskCharArray {
      * We achieve better performance by performing multiplications of long bit sequences
      * in the frequencey domain.
      */
-    static BigInteger parseDigitsRecursive(char[] str, int from, int to, Map<Integer, BigInteger> powersOfTen) {
+    static BigInteger parseDigitsRecursive(char[] str, int from, int to, Map<Integer, BigInteger> powersOfTen, Map<Integer, BigInteger> powersOfFive) {
         int numDigits = to - from;
 
         // Base case: Short sequences can be parsed iteratively.
@@ -76,10 +76,15 @@ class ParseDigitsTaskCharArray {
 
         // Recursion case: Split large sequences up into two parts. The lower part is a multiple of 16 digits.
         int mid = splitFloor16(from, to);
-        BigInteger high = parseDigitsRecursive(str, from, mid, powersOfTen);
-        BigInteger low = parseDigitsRecursive(str, mid, to, powersOfTen);
+        BigInteger high = parseDigitsRecursive(str, from, mid, powersOfTen, powersOfFive);
+        BigInteger low = parseDigitsRecursive(str, mid, to, powersOfTen, powersOfFive);
 
-        high = FftMultiplier.multiply(high, powersOfTen.get(to - mid));
+        int n = to - mid;
+        if (FastIntegerMath.usePowerOfFiveAndShift(n)) {
+            high = FftMultiplier.multiply(high, powersOfFive.get(n)).shiftLeft(n);
+        } else {
+            high = FftMultiplier.multiply(high, powersOfTen.get(n));
+        }
         return low.add(high);
     }
 }

--- a/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JmhMultiplyByPowerOfFiveAndShiftMultiplier.java
+++ b/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JmhMultiplyByPowerOfFiveAndShiftMultiplier.java
@@ -1,0 +1,103 @@
+/*
+ * @(#)JmhMultiplyByPowerOfFiveAndShiftMultiplier.java
+ * Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+ */
+package ch.randelshofer.fastdoubleparser;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.math.BigInteger;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Fork(value = 1, jvmArgsAppend = {
+        "-XX:+UnlockExperimentalVMOptions", "--add-modules", "jdk.incubator.vector"
+        , "--enable-preview"
+})
+@Measurement(iterations = 4, time = 1)
+@Warmup(iterations = 4, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@State(Scope.Benchmark)
+public class JmhMultiplyByPowerOfFiveAndShiftMultiplier {
+
+
+    @Param({
+            "700"
+            , "800" // above this value, variant with bit shift leads
+            , "900"
+            , "2000"
+            , "10000"
+            , "30000"
+    })
+    public int bits;
+    private BigInteger a;
+    private BigInteger b;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        int length = (bits + 7) / 8;
+        byte[] bytesA = new byte[length];
+        byte[] bytesB = new byte[length];
+        Random rng = new Random(0);
+        rng.nextBytes(bytesA);
+        rng.nextBytes(bytesB);
+
+        // to be positive
+        bytesA[0] &= ~(1L << 63);
+        bytesB[0] &= ~(1L << 63);
+
+        // set for b rightmost zeroes like 10^n has
+        final double lg5 = Math.log(5) / Math.log(2);
+        int zeroes = (int) (length / (lg5 + 1));
+        for (int i = 0; i < zeroes; i++) {
+            bytesB[length - 1 - i] = 0;
+        }
+
+        a = new BigInteger(1, bytesA);
+        b = new BigInteger(1, bytesB);
+        System.out.println(b.getLowestSetBit() + " bits from " + length * 8 + " in total are zero");
+    }
+
+
+    @Benchmark
+    public void original(Blackhole blackhole) {
+        blackhole.consume(FftMultiplier.multiply(a, b));
+    }
+
+    @Benchmark
+    public void optimized(Blackhole blackhole) {
+        blackhole.consume(multiply(a, b));
+    }
+
+    // early identical copy of existing method FftMultiplier.multiply() to imitate real performance gain
+    static BigInteger multiply(BigInteger a, BigInteger b) {
+        if (b.signum() == 0 || a.signum() == 0) {
+            return BigInteger.ZERO;
+        }
+
+        int xlen = a.bitLength();
+        int ylen = b.bitLength();
+        if ((long) xlen + ylen > 32L * MAX_MAG_LENGTH) {
+            throw new ArithmeticException("BigInteger would overflow supported range");
+        }
+
+        if (xlen > TOOM_COOK_THRESHOLD
+                && ylen > TOOM_COOK_THRESHOLD
+                && (xlen > FFT_THRESHOLD || ylen > FFT_THRESHOLD)) {
+            throw new IllegalStateException("should not be tested here");
+        }
+        int shift = b.getLowestSetBit();
+        return a.multiply(b.shiftRight(shift)).shiftLeft(shift);
+    }
+
+    private static final int FFT_THRESHOLD = 33220;
+    private static final int MAX_MAG_LENGTH = Integer.MAX_VALUE / Integer.SIZE + 1; // (1 << 26)
+    private static final int TOOM_COOK_THRESHOLD = 240 * 8;
+}
+
+
+
+
+

--- a/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JmhMultiplyByPowerOfFiveAndShiftMultiplier.java
+++ b/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JmhMultiplyByPowerOfFiveAndShiftMultiplier.java
@@ -34,6 +34,7 @@ public class JmhMultiplyByPowerOfFiveAndShiftMultiplier {
     public int bits;
     private BigInteger a;
     private BigInteger b;
+    public int zeroes;
 
     @Setup(Level.Trial)
     public void setUp() {
@@ -50,7 +51,7 @@ public class JmhMultiplyByPowerOfFiveAndShiftMultiplier {
 
         // set for b rightmost zeroes like 10^n has
         final double lg5 = Math.log(5) / Math.log(2);
-        int zeroes = (int) (length / (lg5 + 1));
+        zeroes = (int) (length / (lg5 + 1));
         for (int i = 0; i < zeroes; i++) {
             bytesB[length - 1 - i] = 0;
         }
@@ -68,11 +69,11 @@ public class JmhMultiplyByPowerOfFiveAndShiftMultiplier {
 
     @Benchmark
     public void optimized(Blackhole blackhole) {
-        blackhole.consume(multiply(a, b));
+        blackhole.consume(multiply(a, b, zeroes * 8));
     }
 
     // early identical copy of existing method FftMultiplier.multiply() to imitate real performance gain
-    static BigInteger multiply(BigInteger a, BigInteger b) {
+    static BigInteger multiply(BigInteger a, BigInteger b, int shift) {
         if (b.signum() == 0 || a.signum() == 0) {
             return BigInteger.ZERO;
         }
@@ -88,7 +89,6 @@ public class JmhMultiplyByPowerOfFiveAndShiftMultiplier {
                 && (xlen > FFT_THRESHOLD || ylen > FFT_THRESHOLD)) {
             throw new IllegalStateException("should not be tested here");
         }
-        int shift = b.getLowestSetBit();
         return a.multiply(b.shiftRight(shift)).shiftLeft(shift);
     }
 

--- a/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JmhMultiplyByPowerOfFiveAndShiftMultiplier.java
+++ b/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JmhMultiplyByPowerOfFiveAndShiftMultiplier.java
@@ -11,6 +11,29 @@ import java.math.BigInteger;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Benchmarks for selected floating point strings.
+ * <pre>
+ * # JMH version: 1.36
+ * # VM version: JDK 20.0.1, OpenJDK 64-Bit Server VM, 20.0.1+9-29
+ * # Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz
+ *
+ * Benchmark  (bits)  Mode  Cnt       Score      Error  Units
+ * optimized     700  avgt    4     250.376 ±    3.773  ns/op
+ * optimized     800  avgt    4     317.921 ±   30.518  ns/op
+ * optimized     900  avgt    4     405.584 ±    2.953  ns/op
+ * optimized    2000  avgt    4    1371.457 ±   15.372  ns/op
+ * optimized   10000  avgt    4   30015.376 ± 1073.798  ns/op
+ * optimized   30000  avgt    4  180735.583 ±  825.962  ns/op
+ * original      700  avgt    4     254.843 ±    1.414  ns/op
+ * original      800  avgt    4     339.564 ±    2.898  ns/op
+ * original      900  avgt    4     463.033 ±    4.538  ns/op
+ * original     2000  avgt    4    1828.848 ±  121.480  ns/op
+ * original    10000  avgt    4   33663.669 ± 3189.014  ns/op
+ * original    30000  avgt    4  204170.758 ± 3690.179  ns/op
+ * </pre>
+ */
+
 @Fork(value = 1, jvmArgsAppend = {
         "-XX:+UnlockExperimentalVMOptions", "--add-modules", "jdk.incubator.vector"
         , "--enable-preview"
@@ -24,8 +47,8 @@ public class JmhMultiplyByPowerOfFiveAndShiftMultiplier {
 
 
     @Param({
-            "700"
-            , "800" // above this value, variant with bit shift leads
+            "700" // above this value, variant with bit shift leads
+            , "800"
             , "900"
             , "2000"
             , "10000"
@@ -34,6 +57,7 @@ public class JmhMultiplyByPowerOfFiveAndShiftMultiplier {
     public int bits;
     private BigInteger a;
     private BigInteger b;
+    private BigInteger bs;
     public int zeroes;
 
     @Setup(Level.Trial)
@@ -58,6 +82,7 @@ public class JmhMultiplyByPowerOfFiveAndShiftMultiplier {
 
         a = new BigInteger(1, bytesA);
         b = new BigInteger(1, bytesB);
+        bs = b.shiftRight(zeroes * 8); // preshift value - imitate 5^n
         System.out.println(b.getLowestSetBit() + " bits from " + length * 8 + " in total are zero");
     }
 
@@ -69,32 +94,8 @@ public class JmhMultiplyByPowerOfFiveAndShiftMultiplier {
 
     @Benchmark
     public void optimized(Blackhole blackhole) {
-        blackhole.consume(multiply(a, b, zeroes * 8));
+        blackhole.consume(FftMultiplier.multiply(a, bs).shiftLeft(zeroes * 8));
     }
-
-    // early identical copy of existing method FftMultiplier.multiply() to imitate real performance gain
-    static BigInteger multiply(BigInteger a, BigInteger b, int shift) {
-        if (b.signum() == 0 || a.signum() == 0) {
-            return BigInteger.ZERO;
-        }
-
-        int xlen = a.bitLength();
-        int ylen = b.bitLength();
-        if ((long) xlen + ylen > 32L * MAX_MAG_LENGTH) {
-            throw new ArithmeticException("BigInteger would overflow supported range");
-        }
-
-        if (xlen > TOOM_COOK_THRESHOLD
-                && ylen > TOOM_COOK_THRESHOLD
-                && (xlen > FFT_THRESHOLD || ylen > FFT_THRESHOLD)) {
-            throw new IllegalStateException("should not be tested here");
-        }
-        return a.multiply(b.shiftRight(shift)).shiftLeft(shift);
-    }
-
-    private static final int FFT_THRESHOLD = 33220;
-    private static final int MAX_MAG_LENGTH = Integer.MAX_VALUE / Integer.SIZE + 1; // (1 << 26)
-    private static final int TOOM_COOK_THRESHOLD = 240 * 8;
 }
 
 


### PR DESCRIPTION
It is up to 10% more performant to multiply by power of 5 and then shift left instead of power of 10 for some bit ranges when used standard `BigInteger.multiply()`.

Minimal number of bits, for which is variant more performant was determined to 800 using [benchmark](https://github.com/wrandelshofer/FastDoubleParser/compare/main...xtonik:FastDoubleParser:MULT_5_TO_N_AND_SHIFT?expand=1#diff-aa36511f27fb71ec1fb9781fc9206e5aa836b6efafd564900bdb31f3e5d0cba7).

The use of powers of five is limited from above by constant `FftMultiplier.FFT_THRESHOLD`.

There is several times more places to be changed than provided example in [1041b4b](https://github.com/wrandelshofer/FastDoubleParser/commit/1041b4b407b5ab12056760c98ee1d0f7c4f3e429).

There is some performance trade off in proposed example, as powers of five are computed separately of powers of ten so some powers of ten are stored uselessly since. More aggressive changes to the code are necessary then.