### PR TITLE
npe when parsing valid bigdecimal

### DIFF
--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromByteArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromByteArray.java
@@ -287,7 +287,7 @@ final class JavaBigDecimalFromByteArray extends AbstractBigDecimalParser {
                 fillPowersOfNFloor16Recursive(powersOfTen, integerPartIndex, decimalPointIndex);
                 integerPart = ParseDigitsTaskByteArray.parseDigitsRecursive(str, integerPartIndex, decimalPointIndex, powersOfTen);
             } else {
-                integerPart = ParseDigitsTaskByteArray.parseDigitsRecursive(str, integerPartIndex, decimalPointIndex, null);
+                integerPart = ParseDigitsTaskByteArray.parseDigitsIterative(str, integerPartIndex, decimalPointIndex);
             }
         } else {
             integerPart = BigInteger.ZERO;

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromByteArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromByteArray.java
@@ -304,7 +304,7 @@ final class JavaBigDecimalFromByteArray extends AbstractBigDecimalParser {
                 fillPowersOfNFloor16Recursive(powersOfTen, nonZeroFractionalPartIndex, exponentIndicatorIndex);
                 fractionalPart = ParseDigitsTaskByteArray.parseDigitsRecursive(str, nonZeroFractionalPartIndex, exponentIndicatorIndex, powersOfTen);
             } else {
-                fractionalPart = ParseDigitsTaskByteArray.parseDigitsRecursive(str, nonZeroFractionalPartIndex, exponentIndicatorIndex, null);
+                fractionalPart = ParseDigitsTaskByteArray.parseDigitsIterative(str, nonZeroFractionalPartIndex, exponentIndicatorIndex);
             }
             // If the integer part is not 0, we combine it with the fraction part.
             if (integerPart.signum() == 0) {

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharArray.java
@@ -285,7 +285,7 @@ final class JavaBigDecimalFromCharArray extends AbstractBigDecimalParser {
                 fillPowersOfNFloor16Recursive(powersOfTen, integerPartIndex, decimalPointIndex);
                 integerPart = ParseDigitsTaskCharArray.parseDigitsRecursive(str, integerPartIndex, decimalPointIndex, powersOfTen);
             } else {
-                integerPart = ParseDigitsTaskCharArray.parseDigitsRecursive(str, integerPartIndex, decimalPointIndex, null);
+                integerPart = ParseDigitsTaskCharArray.parseDigitsIterative(str, integerPartIndex, decimalPointIndex);
             }
         } else {
             integerPart = BigInteger.ZERO;

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharArray.java
@@ -302,7 +302,7 @@ final class JavaBigDecimalFromCharArray extends AbstractBigDecimalParser {
                 fillPowersOfNFloor16Recursive(powersOfTen, decimalPointIndex + 1, exponentIndicatorIndex);
                 fractionalPart = ParseDigitsTaskCharArray.parseDigitsRecursive(str, decimalPointIndex + 1, exponentIndicatorIndex, powersOfTen);
             } else {
-                fractionalPart = ParseDigitsTaskCharArray.parseDigitsRecursive(str, decimalPointIndex + 1, exponentIndicatorIndex, null);
+                fractionalPart = ParseDigitsTaskCharArray.parseDigitsIterative(str, decimalPointIndex + 1, exponentIndicatorIndex);
             }
             // If the integer part is not 0, we combine it with the fraction part.
             if (integerPart.signum() == 0) {

--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharSequence.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharSequence.java
@@ -287,7 +287,7 @@ final class JavaBigDecimalFromCharSequence extends AbstractBigDecimalParser {
                 fillPowersOfNFloor16Recursive(powersOfTen, integerPartIndex, decimalPointIndex);
                 integerPart = ParseDigitsTaskCharSequence.parseDigitsRecursive(str, integerPartIndex, decimalPointIndex, powersOfTen);
             } else {
-                integerPart = ParseDigitsTaskCharSequence.parseDigitsRecursive(str, integerPartIndex, decimalPointIndex, null);
+                integerPart = ParseDigitsTaskCharSequence.parseDigitsIterative(str, integerPartIndex, decimalPointIndex);
             }
         } else {
             integerPart = BigInteger.ZERO;
@@ -304,7 +304,7 @@ final class JavaBigDecimalFromCharSequence extends AbstractBigDecimalParser {
                 fillPowersOfNFloor16Recursive(powersOfTen, nonZeroFractionalPartIndex, exponentIndicatorIndex);
                 fractionalPart = ParseDigitsTaskCharSequence.parseDigitsRecursive(str, nonZeroFractionalPartIndex, exponentIndicatorIndex, powersOfTen);
             } else {
-                fractionalPart = ParseDigitsTaskCharSequence.parseDigitsRecursive(str, nonZeroFractionalPartIndex, exponentIndicatorIndex, null);
+                fractionalPart = ParseDigitsTaskCharSequence.parseDigitsIterative(str, nonZeroFractionalPartIndex, exponentIndicatorIndex);
             }
             if (integerPart.signum() == 0) {
                 significand = fractionalPart;

--- a/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalLargeInputTest.java
+++ b/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalLargeInputTest.java
@@ -1,0 +1,30 @@
+/*
+ * @(#)JavaBigDecimalLargeInputTest.java
+ * Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+ */
+package ch.randelshofer.fastdoubleparser;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JavaBigDecimalLargeInputTest {
+
+    @Test
+    public void testLongValidStringFastParse() {
+        String value = genLongValidString(500);
+        assertEquals(new BigDecimal(value), JavaBigDecimalParser.parseBigDecimal(value.toCharArray()));
+    }
+
+    static String genLongValidString(int len) {
+        final StringBuilder sb = new StringBuilder(len+5);
+        sb.append("0.");
+        for (int i = 0; i < len; i++) {
+            sb.append('0');
+        }
+        sb.append('1');
+        return sb.toString();
+    }
+}

--- a/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalLargeInputTest.java
+++ b/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalLargeInputTest.java
@@ -4,18 +4,40 @@
  */
 package ch.randelshofer.fastdoubleparser;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JavaBigDecimalLargeInputTest {
 
+    private static int LEN = 500;
+
     @Test
-    public void testLongValidStringFastParse() {
+    public void testLongValidInputString() {
+        String value = genLongValidString(500);
+        assertEquals(new BigDecimal(value), JavaBigDecimalParser.parseBigDecimal(value));
+    }
+
+    @Test
+    public void testLongValidInputCharArray() {
+        assertTrue(ParseDigitsTaskCharArray.RECURSION_THRESHOLD < LEN,
+                "LEN is greater than RECURSION_THRESHOLD");
         String value = genLongValidString(500);
         assertEquals(new BigDecimal(value), JavaBigDecimalParser.parseBigDecimal(value.toCharArray()));
+    }
+
+    @Test
+    public void testLongValidInputByteArray() {
+        assertTrue(ParseDigitsTaskByteArray.RECURSION_THRESHOLD < LEN,
+                "LEN is greater than RECURSION_THRESHOLD");
+        String value = genLongValidString(500);
+        assertEquals(new BigDecimal(value),
+                JavaBigDecimalParser.parseBigDecimal(value.getBytes(StandardCharsets.ISO_8859_1)));
     }
 
     static String genLongValidString(int len) {


### PR DESCRIPTION
Adds test case based on https://github.com/FasterXML/jackson-core/pull/1162

Only seems to have when `char[]` or `byte[]` is passed, not when String input is used.

```
java.lang.NullPointerException: Cannot invoke "java.util.Map.get(Object)" because "powersOfTen" is null
	at ch.randelshofer.fastdoubleparser.ParseDigitsTaskCharArray.parseDigitsRecursive(ParseDigitsTaskCharArray.java:82)
	at ch.randelshofer.fastdoubleparser.JavaBigDecimalFromCharArray.valueOfBigDecimalString(JavaBigDecimalFromCharArray.java:305)
	at ch.randelshofer.fastdoubleparser.JavaBigDecimalFromCharArray.parseBigDecimalStringWithManyDigits(JavaBigDecimalFromCharArray.java:241)
	at ch.randelshofer.fastdoubleparser.JavaBigDecimalFromCharArray.parseBigDecimalString(JavaBigDecimalFromCharArray.java:41)
	at ch.randelshofer.fastdoubleparser.JavaBigDecimalParser.parseBigDecimal(JavaBigDecimalParser.java:197)
	at ch.randelshofer.fastdoubleparser.JavaBigDecimalParser.parseBigDecimal(JavaBigDecimalParser.java:178)
	at ch.randelshofer.fastdoubleparser.JavaBigDecimalLargeInputTest.testLongValidStringFastParse(JavaBigDecimalLargeInputTest.java:18)
```

The NPE happens because the following line passes a null value (explicitly) for the powersOfTen param.
https://github.com/wrandelshofer/FastDoubleParser/blob/0a5ca6a4f9a43a0a64a324ff95d03464b60da2b2/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JavaBigDecimalFromCharArray.java#L305

The ParseDigitsTaskCharArray.parseDigitsRecursive method cannot handle null values for this param.

Edit: I have changed the code in this PR to call ParseDigitsTaskCharArray.parseDigitsInteractive instead.