### PR TITLE
Fix issue #80: Bug in large array size inputs for JavaBigDecimalParse…

### DIFF
--- a/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractBigDecimalParserTest.java
+++ b/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractBigDecimalParserTest.java
@@ -135,12 +135,15 @@ public abstract class AbstractBigDecimalParserTest {
                 new NumberTestDataSupplier("min exponent", () -> new NumberTestData("1e" + (Integer.MIN_VALUE + 1), BigDecimal.ONE.scaleByPowerOfTen(Integer.MIN_VALUE + 1))),
                 new NumberTestDataSupplier("max exponent", () -> new NumberTestData("1e" + Integer.MAX_VALUE, BigDecimal.ONE.scaleByPowerOfTen(Integer.MAX_VALUE))),
 
-                new NumberTestDataSupplier("8.99...99e68", () -> new NumberTestData("8." + (repeat("9", 19)) + "e68", new BigDecimal("8." + (repeat("9", 19)) + "e68"))),
+                new NumberTestDataSupplier("8.99...99e68", () -> new NumberTestData("8." + (repeat('9', 19)) + "e68", new BigDecimal("8." + (repeat('9', 19)) + "e68"))),
                 new NumberTestDataSupplier("103203303403503603703803903.122232425262728292", () -> new NumberTestData("103203303403503603703803903.122232425262728292", new BigDecimal("103203303403503603703803903.122232425262728292"))),
                 new NumberTestDataSupplier("122232425262728292.103203303403503603703803903", () -> new NumberTestData("122232425262728292.103203303403503603703803903", new BigDecimal("122232425262728292.103203303403503603703803903"))),
                 new NumberTestDataSupplier("-103203303403503603703803903.122232425262728292e6789", () -> new NumberTestData("-103203303403503603703803903.122232425262728292e6789", new BigDecimal("-103203303403503603703803903.122232425262728292e6789"))),
                 new NumberTestDataSupplier("122232425262728292.103203303403503603703803903e-6789", () -> new NumberTestData("122232425262728292.103203303403503603703803903e-6789", new BigDecimal("122232425262728292.103203303403503603703803903e-6789"))),
-                new NumberTestDataSupplier("-122232425262728292.103203303403503603703803903e-6789", () -> new NumberTestData("-122232425262728292.103203303403503603703803903e-6789", new BigDecimal("-122232425262728292.103203303403503603703803903e-6789")))
+                new NumberTestDataSupplier("-122232425262728292.103203303403503603703803903e-6789", () -> new NumberTestData("-122232425262728292.103203303403503603703803903e-6789", new BigDecimal("-122232425262728292.103203303403503603703803903e-6789"))),
+                new NumberTestDataSupplier("-11000.0..0(652 fractional digits)",
+                        () -> new NumberTestData("-11000." + repeat('0', 652),
+                                new BigDecimal("-11000." + repeat('0', 652))))
         );
     }
 
@@ -239,16 +242,16 @@ public abstract class AbstractBigDecimalParserTest {
      */
     protected List<NumberTestDataSupplier> createTestDataForInputClassesInMethodParseBigDecimalStringWithManyDigits() {
         return Arrays.asList(
-                new NumberTestDataSupplier("illegal only negative sign", () -> new NumberTestData("-" + repeat("\000", 32), AbstractNumberParser.SYNTAX_ERROR, NumberFormatException.class)),
-                new NumberTestDataSupplier("illegal only positive sign", () -> new NumberTestData("+" + repeat("\000", 32), AbstractNumberParser.SYNTAX_ERROR, NumberFormatException.class)),
+                new NumberTestDataSupplier("illegal only negative sign", () -> new NumberTestData("-" + repeat('\000', 32), AbstractNumberParser.SYNTAX_ERROR, NumberFormatException.class)),
+                new NumberTestDataSupplier("illegal only positive sign", () -> new NumberTestData("+" + repeat('\000', 32), AbstractNumberParser.SYNTAX_ERROR, NumberFormatException.class)),
 
 
                 new NumberTestDataSupplier("significand with 40 zeroes in integer part", () -> new NumberTestData("significand with 40 zeroes in integer part", repeat("0", 40), BigDecimal::new)),
-                new NumberTestDataSupplier("significand with 40 zeroes in fraction part", () -> new NumberTestData("." + repeat("0", 40), BigDecimal::new)),
+                new NumberTestDataSupplier("significand with 40 zeroes in fraction part", () -> new NumberTestData("." + repeat('0', 40), BigDecimal::new)),
 
-                new NumberTestDataSupplier("significand with 10 leading zeros and 30 digits in integer part", () -> new NumberTestData("significand with 10 leading zeros and 30 digits in integer part", repeat("0", 10) + repeat("9", 30), BigDecimal::new)),
-                new NumberTestDataSupplier("significand with 10 leading zeros and 30 digits in fraction part", () -> new NumberTestData("." + repeat("0", 10) + repeat("9", 30), BigDecimal::new)),
-                new NumberTestDataSupplier("significand with 10 leading zeros and 30 digits in integer part and in fraction part", () -> new NumberTestData("significand with 10 leading zeros and 30 digits in integer part and in fraction part", repeat("0", 10) + repeat("9", 30) + "." + repeat("0", 10) + repeat("9", 30), BigDecimal::new)),
+                new NumberTestDataSupplier("significand with 10 leading zeros and 30 digits in integer part", () -> new NumberTestData("significand with 10 leading zeros and 30 digits in integer part", repeat('0', 10) + repeat('9', 30), BigDecimal::new)),
+                new NumberTestDataSupplier("significand with 10 leading zeros and 30 digits in fraction part", () -> new NumberTestData("." + repeat('0', 10) + repeat('9', 30), BigDecimal::new)),
+                new NumberTestDataSupplier("significand with 10 leading zeros and 30 digits in integer part and in fraction part", () -> new NumberTestData("significand with 10 leading zeros and 30 digits in integer part and in fraction part", repeat('0', 10) + repeat("9", 30) + "." + repeat("0", 10) + repeat("9", 30), BigDecimal::new)),
 
                 new NumberTestDataSupplier("significand with 40 digits in integer part and exponent", () -> new NumberTestData("-1234567890123456789012345678901234567890e887799", BigDecimal::new)),
                 new NumberTestDataSupplier("no significand but exponent 40 digits", () -> new NumberTestData("-e12345678901234567890123456789012345678901234567890", AbstractNumberParser.SYNTAX_ERROR, NumberFormatException.class)),

--- a/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FftMultiplierTest.java
+++ b/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/FftMultiplierTest.java
@@ -31,17 +31,17 @@ public class FftMultiplierTest {
                         "2147483647",
                         "9223372036854775807")),
                 dynamicTest("'3','0'**84 * '4','0'**84", () -> shouldMultiplyFft(
-                        "3" + repeat("0", 84),
-                        "4" + repeat("0", 84))),
+                        "3" + repeat('0', 84),
+                        "4" + repeat('0', 84))),
                 dynamicTest("'-','3','0'**84 * '4','0'**84", () -> shouldMultiplyFft(
-                        "-3" + repeat("0", 84),
-                        "4" + repeat("0", 84))),
+                        "-3" + repeat('0', 84),
+                        "4" + repeat('0', 84))),
                 dynamicTest("'-','3','0'**84 * '-','4','0'**84", () -> shouldMultiplyFft(
-                        "-3" + repeat("0", 84),
-                        "-4" + repeat("0", 84))),
+                        "-3" + repeat('0', 84),
+                        "-4" + repeat('0', 84))),
                 dynamicTest("'3','0'**100_000 * '4','0'**100_000", () -> shouldMultiplyFft(
-                        "3" + repeat("0", 100_000),
-                        "4" + repeat("0", 100_000)))
+                        "3" + repeat('0', 100_000),
+                        "4" + repeat('0', 100_000)))
         );
     }
 
@@ -140,16 +140,16 @@ public class FftMultiplierTest {
     public List<DynamicTest> dynamicTestsSquare() {
         return Arrays.asList(
                 dynamicTest("'3','0'**84", () -> shouldSquare(
-                        "3" + repeat("0", 84)
+                        "3" + repeat('0', 84)
                 )),
                 dynamicTest("'-','3','0'**84", () -> shouldSquare(
-                        "-3" + repeat("0", 84)
+                        "-3" + repeat('0', 84)
                 )),
                 dynamicTest("'-','3','0'**84", () -> shouldSquare(
-                        "-3" + repeat("0", 84)
+                        "-3" + repeat('0', 84)
                 )),
                 dynamicTest("'3','0'**100_000", () -> shouldSquare(
-                        "3" + repeat("0", 100_000)
+                        "3" + repeat('0', 100_000)
                 ))
         );
 

--- a/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JmhBigDecimalScalability.java
+++ b/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JmhBigDecimalScalability.java
@@ -4,7 +4,18 @@
  */
 package ch.randelshofer.fastdoubleparser;
 
-import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.math.BigDecimal;
 import java.util.concurrent.TimeUnit;
@@ -63,7 +74,7 @@ public class JmhBigDecimalScalability {
 
     @Setup(Level.Trial)
     public void setUp() {
-        str = repeat("7", digits);
+        str = repeat('7', digits);
     }
 
     @Benchmark

--- a/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JmhDoubleScalability.java
+++ b/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JmhDoubleScalability.java
@@ -4,7 +4,18 @@
  */
 package ch.randelshofer.fastdoubleparser;
 
-import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 
@@ -67,7 +78,7 @@ public class JmhDoubleScalability {
 
     @Setup(Level.Trial)
     public void setUp() {
-        str = repeat("7", digits);
+        str = repeat('7', digits);
     }
 
     @Benchmark

--- a/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JmhJavaBigIntegerFromByteArrayScalability.java
+++ b/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JmhJavaBigIntegerFromByteArrayScalability.java
@@ -97,12 +97,12 @@ public class JmhJavaBigIntegerFromByteArrayScalability {
     @Setup(Level.Trial)
     public void setUp() {
         String str = "-"
-                + repeat("0", Math.max(0, digits - 646456993))
+                + repeat('0', Math.max(0, digits - 646456993))
                 + repeat("1234567890", (Math.min(646456993, digits) + 9) / 10).substring(0, Math.min(digits, 646456993));
 
         decLiteral = str.getBytes(StandardCharsets.ISO_8859_1);
         str = "-"
-                + repeat("0", Math.max(0, digits - 536870912))
+                + repeat('0', Math.max(0, digits - 536870912))
                 + repeat("12b4c6d7e0", (Math.min(536870912, digits) + 9) / 10).substring(0, Math.min(digits, 536870912));
 
         hexLiteral = str.getBytes(StandardCharsets.ISO_8859_1);

--- a/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JmhJavaDoubleFromCharSequenceScalability.java
+++ b/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/JmhJavaDoubleFromCharSequenceScalability.java
@@ -4,7 +4,18 @@
  */
 package ch.randelshofer.fastdoubleparser;
 
-import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 
@@ -70,7 +81,7 @@ public class JmhJavaDoubleFromCharSequenceScalability {
 
     @Setup(Level.Trial)
     public void setUp() {
-        str = repeat("7", digits - 2);
+        str = repeat('7', digits - 2);
     }
 
     @Benchmark

--- a/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/Strings.java
+++ b/fastdoubleparser-dev/src/test/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/Strings.java
@@ -4,6 +4,9 @@
  */
 package ch.randelshofer.fastdoubleparser;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
 public class Strings {
     public static StringBuilder repeatStringBuilder(String str, int count) {
         StringBuilder b = new StringBuilder(str.length() * count);
@@ -15,5 +18,16 @@ public class Strings {
 
     public static String repeat(String str, int count) {
         return repeatStringBuilder(str, count).toString();
+    }
+
+    public static String repeat(char ch, int count) {
+        if (ch < 256) {
+            byte[] chars = new byte[count];
+            Arrays.fill(chars, (byte) ch);
+            return new String(chars, StandardCharsets.ISO_8859_1);
+        }
+        char[] chars = new char[count];
+        Arrays.fill(chars, ch);
+        return String.copyValueOf(chars);
     }
 }


### PR DESCRIPTION
…r.parseBigDecimal.

AbstractBigDecimalParserTest.java:
- Add a test for the input value that reproduces the problem.

JavaBigDecimalFromByteArray.java,
JavaBigDecimalFromCharArray.java,
JavaBigDecimalFromCharSequence.java:
- Fix the off-by-one issue in JavaBigDecimalFromCharArray.
- Harmonize the code in all 3 implementations.

Strings.java,
FftMultiplierTest.java,
JmhBigDecimalScalability.java,
JmhDoubleScalability.java,
JmhJavaBigIntegerFromByteArrayScalability.java,
JmhJavaDoubleFromCharSequenceScalability.java:
 - Implement a better method for creating Strings from repeated characters.