### PR TITLE
Skip underscores

### DIFF
--- a/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromByteArray.java
+++ b/fastdoubleparser-dev/src/main/java/ch.randelshofer.fastdoubleparser/ch/randelshofer/fastdoubleparser/AbstractJavaFloatingPointBitsFromByteArray.java
@@ -77,6 +77,7 @@ abstract class AbstractJavaFloatingPointBitsFromByteArray extends AbstractFloatV
         int swarLimit = Math.min(endIndex - 4, 1 << 30);
         for (; index < endIndex; index++) {
             ch = str[index];
+            if (ch == '_') continue;
             int digit = (char) (ch - '0');
             if (digit < 10) {
                 // This might overflow, we deal with it later.


### PR DESCRIPTION
Several systems now allow for understands in numeric literals, so skip them if encountered.

This may be too permissive and will allow any number of underscores anywhere in the numeric part of the incoming string.

(I am attempting to adapt this library for use in JRuby's float parser, which must allow underscores.)